### PR TITLE
feat: autoconnect global loading

### DIFF
--- a/packages/react/src/context.test.ts
+++ b/packages/react/src/context.test.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { renderHook } from '../test'
+import { renderHook, wrapper } from '../test'
 import { useContext } from './context'
 
 describe('useContext', () => {
@@ -20,6 +20,7 @@ describe('useContext', () => {
     expect(rest).toMatchInlineSnapshot(`
       {
         "cacheBuster": 1,
+        "connecting": false,
         "connector": undefined,
         "data": undefined,
         "webSocketProvider": undefined,
@@ -27,5 +28,17 @@ describe('useContext', () => {
     `)
     expect(connectors).toBeDefined()
     expect(provider).toBeDefined()
+  })
+
+  it('autoConnect', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useContext(), {
+      wrapper,
+      initialProps: {
+        autoConnect: true,
+      },
+    })
+    expect(result.current.state.connecting).toMatchInlineSnapshot(`true`)
+    await waitForNextUpdate()
+    expect(result.current.state.connecting).toMatchInlineSnapshot(`false`)
   })
 })

--- a/packages/react/src/hooks/accounts/useAccount.ts
+++ b/packages/react/src/hooks/accounts/useAccount.ts
@@ -9,11 +9,8 @@ export type Config = {
 }
 
 export const useAccount = ({ fetchEns }: Config = {}) => {
-  const {
-    state: { connector, data },
-    setState,
-  } = useContext()
-  const address = data?.account
+  const { state: globalState, setState } = useContext()
+  const address = globalState.data?.account
   const [{ data: ens, error: ensError, loading: ensLoading }] = useEnsLookup({
     address,
     skip: !fetchEns,
@@ -39,7 +36,7 @@ export const useAccount = ({ fetchEns }: Config = {}) => {
       data: address
         ? {
             address,
-            connector,
+            connector: globalState.connector,
             ens: ens ? { avatar, name: ens } : undefined,
           }
         : undefined,

--- a/packages/react/src/hooks/accounts/useConnect.ts
+++ b/packages/react/src/hooks/accounts/useConnect.ts
@@ -73,7 +73,7 @@ export const useConnect = () => {
         connectors: globalState.connectors,
       },
       error: state.error,
-      loading: state.loading,
+      loading: state.loading || globalState.connecting,
     },
     connect,
   ] as const


### PR DESCRIPTION
Inspo #37 h/t @sammdec

When `Provider` `autoConnect={true}`, `useConnect` hook has `loading` set to `true` on load. After the auto connect process is tried, the global `connecting` value is switch back to `false`. (Maybe useful in the future to also set the global `connector` so you know what connector is attempting to auto connect.)

Decided to not make changes to `useAccount` loading because it isn't involved at this step of the "connection" process.