### PR TITLE
added context to the export

### DIFF
--- a/.changeset/fifty-emus-search.md
+++ b/.changeset/fifty-emus-search.md
@@ -1,0 +1,5 @@
+---
+'wagmi': minor
+---
+
+Exported Context

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -35,6 +35,7 @@ it('should expose correct exports', () => {
       "erc20ABI",
       "erc721ABI",
       "normalizeChainId",
+      "Context",
     ]
   `)
 })

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -36,4 +36,7 @@ export {
   erc721ABI,
   normalizeChainId,
 } from 'wagmi-private'
+
+export { Context } from './context'
+
 export type { Chain, Data } from 'wagmi-private'


### PR DESCRIPTION
This PR exports the `Context`, so that it can be accessed directly by third party libs that need it for helpers.

For example, with [react-three-fiber](https://github.com/pmndrs/react-three-fiber), a react lib for creating 3d scenes, the [react context is lost inside the 3d scene.](https://docs.pmnd.rs/react-three-fiber/advanced/gotchas#consuming-context-from-a-foreign-provider), and you need to grab the context, and create a new provider within the 3d scene with that context.

For example, it would be great if you can do:
```jsx
import { useContextBridge } from "@react-three/drei"
import { Context as WagmiContext } from 'wagmi'

const SceneContainer = () => {
  const ContextBridge = useContextBridge(WagmiContext)
    return (
      <Canvas>
        <ContextBridge>
          <Scene />
        </ContextBridge>
      </Canvas>
    )
}
```

But `Context` is not currently exported so its not possible to do this.

I can try doing:
`import { Context as WagmiContext } from "wagmi/dist/declarations/src/context";`
However I get an error: "Module not found: Package path ./dist/declarations/src/context is not exported from package"

This PR simply exports the `Context` from the lib.