### PR TITLE
Ensure addresses from accountsChanged events are checksummed

### DIFF
--- a/packages/private/src/connectors/injected.ts
+++ b/packages/private/src/connectors/injected.ts
@@ -175,7 +175,7 @@ export class InjectedConnector extends Connector<
 
   protected onAccountsChanged = (accounts: string[]) => {
     if (accounts.length === 0) this.emit('disconnect')
-    else this.emit('change', { account: accounts[0] })
+    else this.emit('change', { account: getAddress(accounts[0]) })
   }
 
   protected onChainChanged = (chainId: number | string) => {

--- a/packages/private/src/connectors/walletConnect.ts
+++ b/packages/private/src/connectors/walletConnect.ts
@@ -122,7 +122,7 @@ export class WalletConnectConnector extends Connector<
 
   protected onAccountsChanged = (accounts: string[]) => {
     if (accounts.length === 0) this.emit('disconnect')
-    else this.emit('change', { account: accounts[0] })
+    else this.emit('change', { account: getAddress(accounts[0]) })
   }
 
   protected onChainChanged = (chainId: number | string) => {

--- a/packages/private/src/connectors/walletLink.ts
+++ b/packages/private/src/connectors/walletLink.ts
@@ -131,7 +131,7 @@ export class WalletLinkConnector extends Connector<
 
   protected onAccountsChanged = (accounts: string[]) => {
     if (accounts.length === 0) this.emit('disconnect')
-    else this.emit('change', { account: accounts[0] })
+    else this.emit('change', { account: getAddress(accounts[0]) })
   }
 
   protected onChainChanged = (chainId: number | string) => {

--- a/packages/testing/src/connectors/mockConnector.ts
+++ b/packages/testing/src/connectors/mockConnector.ts
@@ -107,7 +107,7 @@ export class MockConnector extends Connector<
 
   protected onAccountsChanged = (accounts: string[]) => {
     if (accounts.length === 0) this.emit('disconnect')
-    else this.emit('change', { account: accounts[0] })
+    else this.emit('change', { account: getAddress(accounts[0]) })
   }
 
   protected onChainChanged = (chainId: number | string) => {


### PR DESCRIPTION
On initial load of useAccount the address is checksummed but I noticed that after switching account in my wallet that the addresses returned were not, this PR fixes that by calling `getAddress` on the addresses returned from those events