### PR TITLE
feat: add improved types for useContractRead

### DIFF
--- a/packages/react/src/hooks/contracts/types.ts
+++ b/packages/react/src/hooks/contracts/types.ts
@@ -1,0 +1,55 @@
+import { ethers } from 'ethers'
+
+type GenericWrite = (...args: any) => Promise<ethers.ContractTransaction>
+
+/**
+ * need to check [T] extends [never], rather than T extends never, to stop it
+ * being distributive
+ *
+ * https://github.com/microsoft/TypeScript/issues/23182#issuecomment-379091887
+ */
+type IfNeverThen<T, Then> = [T] extends [never] ? Then : T
+
+export type WriteMethodNames<
+  Contract extends ethers.Contract,
+  Methods extends Contract['functions'] = Contract['functions'],
+> = {
+  [M in keyof Methods]: Methods[M] extends GenericWrite ? M : never
+}[keyof Methods]
+
+/**
+ * Default to all keyof Methods if the inner mapped type evaluates to never.
+ * This occurs when all Contract methods exten GenericWrite, which is the case
+ * for ethers.Contract whose methods are defined as follows
+ *
+ * methods are mapped to -
+ *  class Contract extends BaseContract {
+ *    readonly [ key: string ]: ContractFunction | any;
+ *  }
+ *  type ContractFunction<T = any> = (...args: Array<any>) => Promise<T>;
+ *
+ *  this trick is really only necessary to allow users to use contract hooks
+ *  without providing a generic.
+ */
+export type ReadMethodNames<
+  Contract extends ethers.Contract,
+  Methods extends Contract['functions'] = Contract['functions'],
+> = IfNeverThen<
+  {
+    [M in keyof Methods]: Methods[M] extends GenericWrite ? never : M
+  }[keyof Methods],
+  keyof Methods
+>
+
+export type MethodNames<Contract extends ethers.Contract> =
+  keyof Contract['functions']
+
+export type Writes<Contract extends ethers.Contract> = Pick<
+  Contract['functions'],
+  WriteMethodNames<Contract>
+>
+
+export type Reads<Contract extends ethers.Contract> = Pick<
+  Contract['functions'],
+  ReadMethodNames<Contract>
+>

--- a/packages/react/src/hooks/contracts/useContractRead.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.ts
@@ -1,34 +1,37 @@
 import * as React from 'react'
 import { CallOverrides, ethers } from 'ethers'
-import { Result } from 'ethers/lib/utils'
 
 import { useBlockNumber } from '../network-status'
 import { useProvider } from '../providers'
 import { Config as UseContractConfig, useContract } from './useContract'
+import { ReadMethodNames, Reads } from './types'
 
-type Config = {
-  args?: any | any[]
+export type Config<
+  Contract extends ethers.Contract,
+  MethodName extends ReadMethodNames<Contract>,
+> = {
+  args?: Parameters<Reads<Contract>[MethodName]>
   overrides?: CallOverrides
   skip?: boolean
   watch?: boolean
 }
 
-type State = {
-  response?: Result
+export type State<
+  Contract extends ethers.Contract,
+  MethodName extends ReadMethodNames<Contract>,
+> = {
+  response?: Awaited<ReturnType<Reads<Contract>[MethodName]>>
   error?: Error
   loading?: boolean
 }
 
-const initialState: State = {
-  loading: false,
-}
-
 export const useContractRead = <
-  Contract extends ethers.Contract = ethers.Contract,
+  Contract extends ethers.Contract,
+  MethodName extends ReadMethodNames<Contract> = ReadMethodNames<Contract>,
 >(
   contractConfig: UseContractConfig,
-  functionName: string,
-  { args, overrides, skip, watch }: Config = {},
+  functionName: MethodName,
+  { args, overrides, skip, watch }: Config<Contract, MethodName> = {},
 ) => {
   const provider = useProvider()
   const contract = useContract<Contract>({
@@ -36,12 +39,14 @@ export const useContractRead = <
     ...contractConfig,
   })
   const [{ data: blockNumber }] = useBlockNumber({ skip: true, watch })
-  const [state, setState] = React.useState<State>(initialState)
+  const [state, setState] = React.useState<State<Contract, MethodName>>({
+    loading: false,
+  })
 
   const read = React.useCallback(
     async (config?: {
-      args?: Config['args']
-      overrides?: Config['overrides']
+      args?: Config<Contract, MethodName>['args']
+      overrides?: Config<Contract, MethodName>['overrides']
     }) => {
       try {
         const config_ = config ?? { args, overrides }
@@ -60,7 +65,7 @@ export const useContractRead = <
           loading: true,
           response: undefined,
         }))
-        const response = (await contract[functionName](...params)) as Result
+        const response = await contract[functionName](...params)
         setState((x) => ({ ...x, loading: false, response }))
         return { data: response, error: undefined }
       } catch (error_) {


### PR DESCRIPTION
- add utility types for inferring method names, arguments, and return
  values
- apply those types to useContractRead

Your ENS/address: 0x0a6B7eE52FcF6505A1fc864dd1D6B8dbD669224F

Started with just useContractRead. Let me know what you think. Particularly on the thoughts I mentioned [in the discussion](https://github.com/tmm/wagmi/discussions/78#discussioncomment-2112897)

@tmm @ericzakariasson  

Apologies again for taking my sweet time with this. 