### PR TITLE
Add keys to options for getDefaultProvider() calls in examples

### DIFF
--- a/examples/next/src/pages/_app.tsx
+++ b/examples/next/src/pages/_app.tsx
@@ -52,9 +52,9 @@ const provider = ({ chainId }: ProviderConfig) =>
   providers.getDefaultProvider(
     isChainSupported(chainId) ? chainId : defaultChain.id,
     {
-      alchemy,
-      etherscan,
-      infuraId,
+      alchemy: alchemy,
+      etherscan: etherscan,
+      infura: infuraId,
     },
   )
 const webSocketProvider = ({ chainId }: ProviderConfig) =>

--- a/examples/remix/app/root.tsx
+++ b/examples/remix/app/root.tsx
@@ -71,9 +71,9 @@ export default function App() {
     providers.getDefaultProvider(
       isChainSupported(chainId) ? chainId : defaultChain.id,
       {
-        alchemy,
-        etherscan,
-        infuraId,
+        alchemy: alchemy,
+        etherscan: etherscan,
+        infura: infuraId,
       },
     )
   const webSocketProvider = ({ chainId }: ProviderConfig) =>

--- a/examples/vite-react/src/main.tsx
+++ b/examples/vite-react/src/main.tsx
@@ -54,9 +54,9 @@ const provider = ({ chainId }: ProviderConfig) =>
   providers.getDefaultProvider(
     isChainSupported(chainId) ? chainId : defaultChain.id,
     {
-      alchemy,
-      etherscan,
-      infuraId,
+      alchemy: alchemy,
+      etherscan: etherscan,
+      infura: infuraId,
     },
   )
 const webSocketProvider = ({ chainId }: ConnectorsConfig) =>


### PR DESCRIPTION
- updates the examples (react, next, remix) to properly set provider API keys in ethers.js `getDefaultProvider()` call

I followed the example code for setting all default providers but was still getting ethers js default API key rate limiting error in the browser console. Network showed ethers requests to APIs (Alchemy, Etherscan, Infura) were still using the ethers default keys. Adding the explicit property names to the options param passed to getDefaultProvider() resolved the issue. As per ethers js docs here: https://docs.ethers.io/v5/api-keys/

Your ENS/address:
mattsalerno.eth
