### PR TITLE
docs: check the nonce during verification

### DIFF
--- a/docs/pages/api/nonce.ts
+++ b/docs/pages/api/nonce.ts
@@ -5,8 +5,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { method } = req
   switch (method) {
     case 'GET':
+      req.session.nonce = generateNonce()
       res.setHeader('Content-Type', 'text/plain')
-      res.send(generateNonce())
+      res.send(req.session.nonce)
       break
     default:
       res.setHeader('Allow', ['GET'])

--- a/docs/pages/api/verify.ts
+++ b/docs/pages/api/verify.ts
@@ -12,6 +12,14 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const { message, signature } = req.body
         const siweMessage = new SiweMessage(message)
         const fields = await siweMessage.validate(signature)
+
+        if (fields.nonce !== req.session.nonce) {
+          res.status(422).json({
+            message: `Invalid nonce.`,
+          })
+          return
+        }
+
         req.session.siwe = fields
         await req.session.save()
 

--- a/docs/pages/guides/sign-in-with-ethereum.mdx
+++ b/docs/pages/guides/sign-in-with-ethereum.mdx
@@ -56,7 +56,7 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
   const { method } = req
   switch (method) {
     case 'GET':
-      req.session.nonce = generateNonce();
+      req.session.nonce = generateNonce()
       res.setHeader('Content-Type', 'text/plain')
       res.send(req.session.nonce)
       break
@@ -90,8 +90,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         if (fields.nonce !== req.session.nonce) {
           res.status(422).json({
             message: `Invalid nonce.`,
-          });
-          return;
+          })
+          return
         }
 
         req.session.siwe = fields

--- a/docs/pages/guides/sign-in-with-ethereum.mdx
+++ b/docs/pages/guides/sign-in-with-ethereum.mdx
@@ -56,8 +56,9 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
   const { method } = req
   switch (method) {
     case 'GET':
+      req.session.nonce = generateNonce();
       res.setHeader('Content-Type', 'text/plain')
-      res.send(generateNonce())
+      res.send(req.session.nonce)
       break
     default:
       res.setHeader('Allow', ['GET'])
@@ -85,6 +86,14 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const { message, signature } = req.body
         const siweMessage = new SiweMessage(message)
         const fields = await siweMessage.validate(signature)
+
+        if (fields.nonce !== req.session.nonce) {
+          res.status(422).json({
+            message: `Invalid nonce.`,
+          });
+          return;
+        }
+
         req.session.siwe = fields
         await req.session.save()
         res.json({ ok: true })

--- a/docs/types/iron-session.d.ts
+++ b/docs/types/iron-session.d.ts
@@ -3,5 +3,6 @@ import { SiweMessage } from 'siwe'
 declare module 'iron-session' {
   interface IronSessionData {
     siwe?: SiweMessage
+    nonce?: string
   }
 }


### PR DESCRIPTION
Just noticed the nonce verification was missing in the Sign-in with Ethereum guide, just added the verification code from the [siwe-quickstart repo](https://github.com/spruceid/siwe-quickstart/blob/main/03_complete_app/backend/src/index.js#L21-L42).

Many thanks for this lib ✌🏻 

Your ENS/address: gomah.eth/0x561b5F3745a1a9e44Ac16010bd670eeAE0cA3379