### PR TITLE
feat: add shim for metamask chain change disconnect

### DIFF
--- a/.changeset/thin-wolves-joke.md
+++ b/.changeset/thin-wolves-joke.md
@@ -1,0 +1,7 @@
+---
+'wagmi-private': patch
+'wagmi': patch
+'wagmi-testing': patch
+---
+
+add shim for metamask chain changed to prevent disconnect

--- a/packages/private/src/constants/chains.ts
+++ b/packages/private/src/constants/chains.ts
@@ -169,7 +169,7 @@ export const chain: Record<ChainName, Chain> = {
     name: 'Rinkeby Arbitrum',
     nativeCurrency: {
       name: 'Rinkeby ArbEther',
-      symbol: 'rinkArbETH',
+      symbol: 'ARETH',
       decimals: 18,
     },
     rpcUrls: ['https://rinkeby.arbitrum.io/rpc'],
@@ -214,7 +214,7 @@ export const chain: Record<ChainName, Chain> = {
   },
   hardhat: {
     id: 31_337,
-    name: 'hardhat',
+    name: 'Hardhat',
     rpcUrls: ['http://127.0.0.1:8545'],
   },
 }


### PR DESCRIPTION
MetaMask 10.9.3 emits disconnect event when chain is changed. https://github.com/MetaMask/metamask-extension/issues/13375#issuecomment-1027663334

This flag disables the disconnect event and relies on the accountsChanged event for updating wallet connection. This workaround is experimental and might result in stale connections.