### PR TITLE
refactor: rename package

### DIFF
--- a/.changeset/cold-years-breathe.md
+++ b/.changeset/cold-years-breathe.md
@@ -1,0 +1,7 @@
+---
+'wagmi-core': patch
+'wagmi': patch
+'wagmi-testing': patch
+---
+
+rename wagmi-private to wagmi-core

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @wagmi/core
+# wagmi-core
 
 ## 0.1.10
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@wagmi/core",
+  "name": "wagmi-core",
   "license": "MIT",
   "version": "0.1.10",
   "ethereum": "awkweb.eth",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -7,7 +7,7 @@
 - [#192](https://github.com/tmm/wagmi/pull/192) [`428cedb`](https://github.com/tmm/wagmi/commit/428cedb3dec4e3e4b9f4559c8e65932e05f94e05) Thanks [@tmm](https://github.com/tmm)! - rename core and testing packages
 
 - Updated dependencies [[`428cedb`](https://github.com/tmm/wagmi/commit/428cedb3dec4e3e4b9f4559c8e65932e05f94e05)]:
-  - @wagmi/core@0.1.10
+  - wagmi-core@0.1.10
 
 ## 0.2.13
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,14 +46,14 @@
   },
   "dependencies": {
     "@ethersproject/providers": "^5.5.1",
-    "@wagmi/core": "0.1.10",
     "@walletconnect/ethereum-provider": "1.7.1",
+    "wagmi-core": "0.1.10",
     "walletlink": "^2.2.8"
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^7.0.2",
     "@types/react": "^17.0.0",
-    "@wagmi/testing": "0.1.10",
+    "wagmi-testing": "0.1.10",
     "@walletconnect/ethereum-provider": "1.7.1",
     "ethers": "^5.5.1",
     "react": "^17.0.0",

--- a/packages/react/src/connectors/injected.ts
+++ b/packages/react/src/connectors/injected.ts
@@ -1,1 +1,1 @@
-export { InjectedConnector } from '@wagmi/core'
+export { InjectedConnector } from 'wagmi-core'

--- a/packages/react/src/connectors/walletConnect.ts
+++ b/packages/react/src/connectors/walletConnect.ts
@@ -1,1 +1,1 @@
-export { WalletConnectConnector } from '@wagmi/core/connectors/walletConnect'
+export { WalletConnectConnector } from 'wagmi-core/connectors/walletConnect'

--- a/packages/react/src/connectors/walletLink.ts
+++ b/packages/react/src/connectors/walletLink.ts
@@ -1,1 +1,1 @@
-export { WalletLinkConnector } from '@wagmi/core/connectors/walletLink'
+export { WalletLinkConnector } from 'wagmi-core/connectors/walletLink'

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -5,7 +5,7 @@ import {
   WebSocketProvider,
   getDefaultProvider,
 } from '@ethersproject/providers'
-import { Connector, ConnectorData, InjectedConnector } from '@wagmi/core'
+import { Connector, ConnectorData, InjectedConnector } from 'wagmi-core'
 
 import { useLocalStorage } from './hooks'
 

--- a/packages/react/src/hooks/accounts/useBalance.test.ts
+++ b/packages/react/src/hooks/accounts/useBalance.test.ts
@@ -1,4 +1,4 @@
-import { wallets } from '@wagmi/testing'
+import { wallets } from 'wagmi-testing'
 
 import { actHook, renderHook } from '../../../test'
 import { useConnect } from './useConnect'

--- a/packages/react/src/hooks/accounts/useBalance.ts
+++ b/packages/react/src/hooks/accounts/useBalance.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { BigNumber, ethers, utils } from 'ethers'
-import { Unit, defaultChains, defaultL2Chains, erc20ABI } from '@wagmi/core'
+import { Unit, defaultChains, defaultL2Chains, erc20ABI } from 'wagmi-core'
 
 import { useContext } from '../../context'
 import { useProvider } from '../providers'

--- a/packages/react/src/hooks/accounts/useConnect.test.ts
+++ b/packages/react/src/hooks/accounts/useConnect.test.ts
@@ -1,4 +1,4 @@
-import { MockConnector, defaultChains, wallets } from '@wagmi/testing'
+import { MockConnector, defaultChains, wallets } from 'wagmi-testing'
 
 import { actHook, renderHook, wrapper } from '../../../test'
 import { useConnect } from './useConnect'

--- a/packages/react/src/hooks/accounts/useConnect.ts
+++ b/packages/react/src/hooks/accounts/useConnect.ts
@@ -3,7 +3,7 @@ import {
   Connector,
   ConnectorAlreadyConnectedError,
   ConnectorData,
-} from '@wagmi/core'
+} from 'wagmi-core'
 
 import { useContext } from '../../context'
 import { useCancel } from '../utils'

--- a/packages/react/src/hooks/accounts/useNetwork.ts
+++ b/packages/react/src/hooks/accounts/useNetwork.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Chain, SwitchChainError, allChains } from '@wagmi/core'
+import { Chain, SwitchChainError, allChains } from 'wagmi-core'
 
 import { useContext } from '../../context'
 import { useCancel } from '../utils'

--- a/packages/react/src/hooks/accounts/useSignMessage.ts
+++ b/packages/react/src/hooks/accounts/useSignMessage.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Bytes } from 'ethers/lib/utils'
-import { ConnectorNotFoundError, UserRejectedRequestError } from '@wagmi/core'
+import { ConnectorNotFoundError, UserRejectedRequestError } from 'wagmi-core'
 
 import { useContext } from '../../context'
 import { useCancel } from '../utils'

--- a/packages/react/src/hooks/contracts/useContract.test.ts
+++ b/packages/react/src/hooks/contracts/useContract.test.ts
@@ -1,7 +1,7 @@
 import { Signer, providers } from 'ethers'
 import { Provider } from '@ethersproject/providers'
-import { erc20ABI } from '@wagmi/core'
-import { contracts, infuraApiKey } from '@wagmi/testing'
+import { erc20ABI } from 'wagmi-core'
+import { contracts, infuraApiKey } from 'wagmi-testing'
 
 import { renderHook } from '../../../test'
 import { useContract } from './useContract'

--- a/packages/react/src/hooks/contracts/useContractEvent.test.ts
+++ b/packages/react/src/hooks/contracts/useContractEvent.test.ts
@@ -1,5 +1,5 @@
-import { erc20ABI } from '@wagmi/core'
-import { contracts } from '@wagmi/testing'
+import { erc20ABI } from 'wagmi-core'
+import { contracts } from 'wagmi-testing'
 
 import { renderHook } from '../../../test'
 import { useContractEvent } from './useContractEvent'

--- a/packages/react/src/hooks/contracts/useContractWrite.ts
+++ b/packages/react/src/hooks/contracts/useContractWrite.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { CallOverrides, ethers } from 'ethers'
 import { TransactionResponse } from '@ethersproject/providers'
-import { ConnectorNotFoundError, UserRejectedRequestError } from '@wagmi/core'
+import { ConnectorNotFoundError, UserRejectedRequestError } from 'wagmi-core'
 
 import { useContext } from '../../context'
 import { Config as UseContractConfig, useContract } from './useContract'

--- a/packages/react/src/hooks/contracts/useToken.test.ts
+++ b/packages/react/src/hooks/contracts/useToken.test.ts
@@ -1,4 +1,4 @@
-import { contracts } from '@wagmi/testing'
+import { contracts } from 'wagmi-testing'
 
 import { actHook, renderHook } from '../../../test'
 import { useConnect } from '../accounts'

--- a/packages/react/src/hooks/contracts/useToken.ts
+++ b/packages/react/src/hooks/contracts/useToken.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { BigNumber, ethers, utils } from 'ethers'
-import { Unit, erc20ABI } from '@wagmi/core'
+import { Unit, erc20ABI } from 'wagmi-core'
 
 import { useContext } from '../../context'
 import { useProvider } from '../providers'

--- a/packages/react/src/hooks/ens/useEnsAvatar.test.ts
+++ b/packages/react/src/hooks/ens/useEnsAvatar.test.ts
@@ -1,4 +1,4 @@
-import { wallets } from '@wagmi/testing'
+import { wallets } from 'wagmi-testing'
 
 import { actHook, renderHook } from '../../../test'
 import { useEnsAvatar } from './useEnsAvatar'

--- a/packages/react/src/hooks/ens/useEnsLookup.test.ts
+++ b/packages/react/src/hooks/ens/useEnsLookup.test.ts
@@ -1,4 +1,4 @@
-import { wallets } from '@wagmi/testing'
+import { wallets } from 'wagmi-testing'
 
 import { actHook, renderHook } from '../../../test'
 import { useEnsLookup } from './useEnsLookup'

--- a/packages/react/src/hooks/ens/useEnsResolveName.test.ts
+++ b/packages/react/src/hooks/ens/useEnsResolveName.test.ts
@@ -1,4 +1,4 @@
-import { wallets } from '@wagmi/testing'
+import { wallets } from 'wagmi-testing'
 
 import { actHook, renderHook } from '../../../test'
 import { useEnsResolveName } from './useEnsResolveName'

--- a/packages/react/src/hooks/ens/useEnsResolver.test.ts
+++ b/packages/react/src/hooks/ens/useEnsResolver.test.ts
@@ -1,4 +1,4 @@
-import { wallets } from '@wagmi/testing'
+import { wallets } from 'wagmi-testing'
 
 import { actHook, renderHook } from '../../../test'
 import { useEnsResolver } from './useEnsResolver'

--- a/packages/react/src/hooks/network-status/useFeeData.ts
+++ b/packages/react/src/hooks/network-status/useFeeData.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { BigNumberish, utils } from 'ethers'
 import { FeeData } from '@ethersproject/providers'
-import { Unit } from '@wagmi/core'
+import { Unit } from 'wagmi-core'
 
 import { useProvider } from '../providers'
 import { useCacheBuster, useCancel } from '../utils'

--- a/packages/react/src/hooks/transactions/useTransaction.ts
+++ b/packages/react/src/hooks/transactions/useTransaction.ts
@@ -3,7 +3,7 @@ import {
   TransactionRequest,
   TransactionResponse,
 } from '@ethersproject/providers'
-import { ConnectorNotFoundError, UserRejectedRequestError } from '@wagmi/core'
+import { ConnectorNotFoundError, UserRejectedRequestError } from 'wagmi-core'
 
 import { useContext } from '../../context'
 import { useCancel } from '../utils'

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -51,6 +51,6 @@ export {
   ConnectorNotFoundError,
   SwitchChainError,
   UserRejectedRequestError,
-} from '@wagmi/core'
+} from 'wagmi-core'
 
-export type { Chain, ConnectorData } from '@wagmi/core'
+export type { Chain, ConnectorData } from 'wagmi-core'

--- a/packages/react/test/index.tsx
+++ b/packages/react/test/index.tsx
@@ -10,7 +10,7 @@ import {
   defaultChains,
   infuraApiKey,
   wallets,
-} from '@wagmi/testing'
+} from 'wagmi-testing'
 
 import { Provider, ProviderProps } from '../src'
 

--- a/packages/react/test/setup.ts
+++ b/packages/react/test/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { server } from '@wagmi/testing'
+import { server } from 'wagmi-testing'
 
 // Establish API mocking before all tests.
 beforeAll(() => server.listen())

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @wagmi/testing
+# wagmi-testing
 
 ## 0.1.10
 
@@ -7,7 +7,7 @@
 - [#192](https://github.com/tmm/wagmi/pull/192) [`428cedb`](https://github.com/tmm/wagmi/commit/428cedb3dec4e3e4b9f4559c8e65932e05f94e05) Thanks [@tmm](https://github.com/tmm)! - rename core and testing packages
 
 - Updated dependencies [[`428cedb`](https://github.com/tmm/wagmi/commit/428cedb3dec4e3e4b9f4559c8e65932e05f94e05)]:
-  - @wagmi/core@0.1.10
+  - wagmi-core@0.1.10
 
 ## 0.1.9
 

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@wagmi/testing",
+  "name": "wagmi-testing",
   "description": "Testing utils for wagmi",
   "license": "MIT",
   "version": "0.1.10",
@@ -28,10 +28,10 @@
   },
   "dependencies": {
     "@ethersproject/providers": "^5.5.1",
-    "@wagmi/core": "0.1.10",
     "eventemitter3": "^4.0.7",
     "msw": "^0.36.3",
-    "ts-pattern": "^3.3.4"
+    "ts-pattern": "^3.3.4",
+    "wagmi-core": "0.1.10"
   },
   "devDependencies": {
     "ethers": "^5.5.1"

--- a/packages/testing/src/connectors/mockConnector.test.ts
+++ b/packages/testing/src/connectors/mockConnector.test.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers'
-import { defaultChains } from '@wagmi/core'
+import { defaultChains } from 'wagmi-core'
 
 import { contracts, wallets } from '../constants'
 import { MockConnector } from './mockConnector'

--- a/packages/testing/src/connectors/mockConnector.ts
+++ b/packages/testing/src/connectors/mockConnector.ts
@@ -5,7 +5,7 @@ import {
   allChains,
   defaultChains,
   normalizeChainId,
-} from '@wagmi/core'
+} from 'wagmi-core'
 
 import { wallets } from '../constants'
 import { MockProvider, MockProviderOptions } from './mockProvider'

--- a/packages/testing/src/connectors/mockProvider.ts
+++ b/packages/testing/src/connectors/mockProvider.ts
@@ -1,6 +1,6 @@
 import { default as EventEmitter } from 'eventemitter3'
 import { ethers } from 'ethers'
-import { UserRejectedRequestError } from '@wagmi/core'
+import { UserRejectedRequestError } from 'wagmi-core'
 import { getAddress } from 'ethers/lib/utils'
 
 export type MockProviderOptions = {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,4 +1,4 @@
-export { defaultChains } from '@wagmi/core'
+export { defaultChains } from 'wagmi-core'
 
 export { MockConnector } from './connectors'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,38 +236,38 @@ importers:
       '@ethersproject/providers': ^5.5.1
       '@testing-library/react-hooks': ^7.0.2
       '@types/react': ^17.0.0
-      '@wagmi/core': 0.1.10
-      '@wagmi/testing': 0.1.10
       '@walletconnect/ethereum-provider': 1.7.1
       ethers: ^5.5.1
       react: ^17.0.0
+      wagmi-core: 0.1.10
+      wagmi-testing: 0.1.10
       walletlink: ^2.2.8
     dependencies:
       '@ethersproject/providers': 5.5.1
-      '@wagmi/core': link:../core
       '@walletconnect/ethereum-provider': 1.7.1
+      wagmi-core: link:../core
       walletlink: 2.3.0_@babel+core@7.16.5
     devDependencies:
       '@testing-library/react-hooks': 7.0.2_react@17.0.2
       '@types/react': 17.0.37
-      '@wagmi/testing': link:../testing
       ethers: 5.5.2
       react: 17.0.2
+      wagmi-testing: link:../testing
 
   packages/testing:
     specifiers:
       '@ethersproject/providers': ^5.5.1
-      '@wagmi/core': 0.1.10
       ethers: ^5.5.1
       eventemitter3: ^4.0.7
       msw: ^0.36.3
       ts-pattern: ^3.3.4
+      wagmi-core: 0.1.10
     dependencies:
       '@ethersproject/providers': 5.5.1
-      '@wagmi/core': link:../core
       eventemitter3: 4.0.7
       msw: 0.36.3
       ts-pattern: 3.3.4
+      wagmi-core: link:../core
     devDependencies:
       ethers: 5.5.2
 


### PR DESCRIPTION
`@wagmi` scope isn't available on npm :(

Renaming `wagmi-private` to `wagmi-core` for now instead.