### PR TITLE
Typo in wagmi/guides/connectors

### DIFF
--- a/docs/pages/guides/connectors.mdx
+++ b/docs/pages/guides/connectors.mdx
@@ -2,7 +2,7 @@ import Callout from 'nextra-theme-docs/callout'
 
 # Connectors
 
-Connectors allow users to securly connect their wallet to your app. When using wagmi, you configure whatever connectors you want to use and wagmi handles the rest!
+Connectors allow users to securely connect their wallet to your app. When using wagmi, you configure whatever connectors you want to use and wagmi handles the rest!
 
 ## Built-in Connectors
 


### PR DESCRIPTION
securly -> securely

Your ENS/address:
👦🏻👦🏻.eth
