### PR TITLE
feat:support EIP-712 sign typed data

### DIFF
--- a/.changeset/brave-mugs-deny.md
+++ b/.changeset/brave-mugs-deny.md
@@ -1,0 +1,7 @@
+---
+'docs': minor
+'wagmi': minor
+'wagmi-testing': minor
+---
+
+Support EIP-712 sign typed data.

--- a/docs/pages/docs/hooks/useSignTypedData.mdx
+++ b/docs/pages/docs/hooks/useSignTypedData.mdx
@@ -1,0 +1,92 @@
+# useSignTypedData
+
+Hook for signing the typed data value with types data structure for domain using the [EIP-712](https://eips.ethereum.org/EIPS/eip-712) specification.
+
+```tsx
+import { useSignTypedData } from 'wagmi'
+```
+
+## Usage
+
+The following examples use the typed data.
+
+```tsx
+import { useSignTypedData } from 'wagmi'
+
+// All properties on a domain are optional
+const domain = {
+  name: 'Ether Mail',
+  version: '1',
+  chainId: 1,
+  verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+}
+
+// The named list of all type definitions
+const types = {
+  Person: [
+    { name: 'name', type: 'string' },
+    { name: 'wallet', type: 'address' },
+  ],
+  Mail: [
+    { name: 'from', type: 'Person' },
+    { name: 'to', type: 'Person' },
+    { name: 'contents', type: 'string' },
+  ],
+}
+
+const value = {
+  from: {
+    name: 'Cow',
+    wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+  },
+  to: {
+    name: 'Bob',
+    wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+  },
+  contents: 'Hello, Bob!',
+}
+
+const App = () => {
+  const [{ data, error, loading }, signTypedData] = useSignTypedData({
+    domain,
+    types,
+    value,
+  })
+
+  if (!data)
+    return (
+      <button disabled={loading} onClick={async () => await signTypedData()}>
+        Sign typed Data
+      </button>
+    )
+
+  return (
+    <div>
+      {data && <div>Signature: {data}</div>}
+      {error && <div>Error signing message</div>}
+    </div>
+  )
+}
+```
+
+## Return Values
+
+### result
+
+```ts
+{
+  data?: string
+  error?: Error
+  loading?: boolean
+}
+```
+
+### signTypedData
+
+```ts
+(config?: {
+  domain: TypedDataDomain
+  types: Record<string, Array<TypedDataField>>
+  value: Record<string, any>
+}) => Promise<{ data?: string; error?: Error }>
+```

--- a/packages/react/src/hooks/accounts/useSignTypedData.test.ts
+++ b/packages/react/src/hooks/accounts/useSignTypedData.test.ts
@@ -1,0 +1,149 @@
+import { verifyTypedData } from 'ethers/lib/utils'
+
+import { actHook, renderHook } from '../../../test'
+import { useConnect } from './useConnect'
+import { Config, useSignTypedData } from './useSignTypedData'
+
+// All properties on a domain are optional
+const domain = {
+  name: 'Ether Mail',
+  version: '1',
+  chainId: 1,
+  verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+}
+
+// The named list of all type definitions
+const types = {
+  Person: [
+    { name: 'name', type: 'string' },
+    { name: 'wallet', type: 'address' },
+  ],
+  Mail: [
+    { name: 'from', type: 'Person' },
+    { name: 'to', type: 'Person' },
+    { name: 'contents', type: 'string' },
+  ],
+}
+
+// The data to sign
+const value = {
+  from: {
+    name: 'Cow',
+    wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+  },
+  to: {
+    name: 'Bob',
+    wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+  },
+  contents: 'Hello, Bob!',
+}
+
+const useSignTypedDataWithConnect = (config: { typedData?: Config } = {}) => {
+  const connect = useConnect()
+  const signTypedData = useSignTypedData(config.typedData)
+  return { connect, signTypedData } as const
+}
+
+describe('useSignTypedData', () => {
+  it('on mount', async () => {
+    const { result } = renderHook(() =>
+      useSignTypedData({
+        domain,
+        types,
+        value,
+      }),
+    )
+    expect(result.current[0]).toMatchInlineSnapshot(`
+      {
+        "data": undefined,
+        "error": undefined,
+        "loading": false,
+      }
+    `)
+    expect(result.current[1]).toBeDefined()
+  })
+
+  describe('signTypedData', () => {
+    it('uses config', async () => {
+      const { result } = renderHook(() =>
+        useSignTypedDataWithConnect({
+          typedData: { domain, types, value },
+        }),
+      )
+
+      expect(result.current.signTypedData[0]).toMatchInlineSnapshot(`
+        {
+          "data": undefined,
+          "error": undefined,
+          "loading": false,
+        }
+      `)
+
+      await actHook(async () => {
+        const mockConnector = result.current.connect[0].data.connectors[0]
+        await result.current.connect[1](mockConnector)
+
+        const res = await result.current.signTypedData[1]()
+        if (res.error) throw new Error('No signature')
+        const account =
+          await result.current.connect[0].data.connector?.getAccount()
+        const recoveredAccount = verifyTypedData(domain, types, value, res.data)
+        expect(account).toEqual(recoveredAccount)
+      })
+
+      expect(result.current.signTypedData[0]).toMatchInlineSnapshot(`
+        {
+          "data": "0x8324a2818a0960e6cd037a93eddd38371c74c5299a76110ae72a7084295464ae48f6ea5388440723bd26c3cef91878b3aa95d93d390ce542817d3fbdbbc240161b",
+          "error": undefined,
+          "loading": false,
+        }
+      `)
+      const account =
+        await result.current.connect[0].data.connector?.getAccount()
+      const recoveredAccount = verifyTypedData(
+        domain,
+        types,
+        value,
+        <any>result.current.signTypedData[0]?.data,
+      )
+      expect(account).toEqual(recoveredAccount)
+    })
+
+    it('uses params', async () => {
+      const { result } = renderHook(() => useSignTypedDataWithConnect())
+
+      await actHook(async () => {
+        const mockConnector = result.current.connect[0].data.connectors[0]
+        await result.current.connect[1](mockConnector)
+
+        const res = await result.current.signTypedData[1]({
+          domain,
+          types,
+          value,
+        })
+        if (res.error) throw new Error('No signature')
+        const account =
+          await result.current.connect[0].data.connector?.getAccount()
+        const recoveredAccount = verifyTypedData(domain, types, value, res.data)
+        expect(account).toEqual(recoveredAccount)
+      })
+    })
+
+    it('has error', async () => {
+      const { result } = renderHook(() => useSignTypedDataWithConnect())
+
+      await actHook(async () => {
+        const mockConnector = result.current.connect[0].data.connectors[0]
+        await result.current.connect[1](mockConnector)
+
+        const res = await result.current.signTypedData[1]()
+        expect(res).toMatchInlineSnapshot(`
+          {
+            "data": undefined,
+            "error": [Error: domain is required],
+          }
+        `)
+      })
+    })
+  })
+})

--- a/packages/react/src/hooks/accounts/useSignTypedData.ts
+++ b/packages/react/src/hooks/accounts/useSignTypedData.ts
@@ -1,0 +1,99 @@
+import { BigNumberish, BytesLike } from 'ethers/lib/ethers'
+import * as React from 'react'
+
+import { ConnectorNotFoundError, UserRejectedRequestError } from 'wagmi-core'
+
+import { useContext } from '../../context'
+import { useCancel } from '../utils'
+
+interface TypedDataDomain {
+  name?: string
+  version?: string
+  chainId?: BigNumberish
+  verifyingContract?: string
+  salt?: BytesLike
+}
+
+interface TypedDataField {
+  name: string
+  type: string
+}
+
+export type Config = {
+  domain?: TypedDataDomain
+  types?: Record<string, Array<TypedDataField>>
+  value?: Record<string, any>
+}
+
+type State = {
+  signature?: string
+  error?: Error
+  loading?: boolean
+}
+
+const initialState: State = {
+  loading: false,
+}
+
+export const useSignTypedData = ({ domain, types, value }: Config = {}) => {
+  const {
+    state: { connector },
+  } = useContext()
+  const [state, setState] = React.useState<State>(initialState)
+
+  const cancelQuery = useCancel()
+  const signTypedData = React.useCallback(
+    async (config?: {
+      domain?: Config['domain']
+      types?: Config['types']
+      value?: Config['value']
+    }) => {
+      let didCancel = false
+      cancelQuery(() => {
+        didCancel = true
+      })
+
+      try {
+        const config_ = config ?? { domain, types, value }
+        if (!config_.domain) throw new Error('domain is required')
+        if (!config_.types) throw new Error('type is required')
+        if (!config_.value) throw new Error('value is required')
+        if (!connector) throw new ConnectorNotFoundError()
+
+        setState((x) => ({ ...x, error: undefined, loading: true }))
+        const signer = await connector.getSigner()
+
+        // Method name may be changed in the future, see https://docs.ethers.io/v5/api/signer/#Signer-signTypedData
+        const signature = await signer._signTypedData(
+          config_.domain,
+          config_.types,
+          config_.value,
+        )
+
+        if (!didCancel) {
+          setState((x) => ({ ...x, signature, loading: false }))
+        }
+        return { data: signature, error: undefined }
+      } catch (error_) {
+        let error: Error = <Error>error_
+        if ((<ProviderRpcError>error_).code === 4001)
+          error = new UserRejectedRequestError()
+        if (!didCancel) {
+          setState((x) => ({ ...x, error, loading: false }))
+        }
+
+        return { data: undefined, error }
+      }
+    },
+    [cancelQuery, connector, domain, types, value],
+  )
+
+  return [
+    {
+      data: state.signature,
+      error: state.error,
+      loading: state.loading,
+    },
+    signTypedData,
+  ] as const
+}


### PR DESCRIPTION
### Motivation
Sign plain text message may confuse user, especially sign some text looks like OpenSea's list message. So more devs are going to use typed data in favor of plain text(eg. OpenSea's new list contract).
### Changes
- support EIP-712: Ethereum typed structured data hashing and signing
- use `signer._signTypedData` to implementation this feature
- 🔗 ethers.js signTypedData doc link: https://docs.ethers.io/v5/api/signer/#Signer-signTypedData

Your ENS/address: sunskyxh.eth
