### PR TITLE
[bug] useAccount "loading" should reflect ENS lookup from first render

### DIFF
--- a/packages/react/src/hooks/ens/useEnsLookup.test.ts
+++ b/packages/react/src/hooks/ens/useEnsLookup.test.ts
@@ -86,6 +86,17 @@ describe('useEnsLookup', () => {
     `)
   })
 
+  it('not loading from first render', async () => {
+    const { result } = renderHook(() => useEnsLookup({ skip: true }))
+    expect(result.current[0]).toMatchInlineSnapshot(`
+      {
+        "data": undefined,
+        "error": undefined,
+        "loading": false,
+      }
+    `)
+  })
+
   it('skip', async () => {
     const { result } = renderHook(() => useEnsLookup({ skip: true }))
     expect(result.current[0]).toMatchInlineSnapshot(`

--- a/packages/react/src/hooks/ens/useEnsLookup.test.ts
+++ b/packages/react/src/hooks/ens/useEnsLookup.test.ts
@@ -75,6 +75,17 @@ describe('useEnsLookup', () => {
     })
   })
 
+  it('loading from first render', async () => {
+    const { result } = renderHook(() => useEnsLookup())
+    expect(result.current[0]).toMatchInlineSnapshot(`
+      {
+        "data": undefined,
+        "error": undefined,
+        "loading": true,
+      }
+    `)
+  })
+
   it('skip', async () => {
     const { result } = renderHook(() => useEnsLookup({ skip: true }))
     expect(result.current[0]).toMatchInlineSnapshot(`

--- a/packages/react/src/hooks/ens/useEnsLookup.ts
+++ b/packages/react/src/hooks/ens/useEnsLookup.ts
@@ -16,14 +16,14 @@ type State = {
   loading: boolean
 }
 
-const initialState: State = {
-  loading: false,
-}
+const getInitialState = (skip: boolean): State => ({
+  loading: !skip,
+})
 
 export const useEnsLookup = ({ address, skip }: Config = {}) => {
   const cacheBuster = useCacheBuster()
   const provider = useProvider()
-  const [state, setState] = React.useState<State>(initialState)
+  const [state, setState] = React.useState<State>(getInitialState(!!skip))
 
   const cancelQuery = useCancel()
   const lookupAddress = React.useCallback(


### PR DESCRIPTION
Your ENS/address: davisshaver.eth

See https://github.com/tmm/wagmi/issues/263