### PR TITLE
docs: connector guide URL from provider docs

### DIFF
--- a/docs/pages/docs/provider.mdx
+++ b/docs/pages/docs/provider.mdx
@@ -85,7 +85,7 @@ const App = () => (
 
 <Callout emoji="💡">
   Learn more about wagmi's built-in connectors or how to create a custom
-  connector [here](/docs/connectors).
+  connector [here](/guides/connectors).
 </Callout>
 
 ### provider (optional)


### PR DESCRIPTION
Your ENS/address: `ped.eth`

smol docs fix 

![CleanShot 2022-03-23 at 22 44 48@2x](https://user-images.githubusercontent.com/372831/159801177-ab96c0d6-193d-4e67-8159-b701a307d920.png)
