### PR TITLE
Add provider dynamic import example

### DIFF
--- a/examples/next/src/components/Provider.tsx
+++ b/examples/next/src/components/Provider.tsx
@@ -1,0 +1,78 @@
+// Imports
+import React from 'react'
+import { providers } from 'ethers'
+import {
+  Connector,
+  Provider as WagmiProvider,
+  chain,
+  defaultChains,
+} from 'wagmi'
+import { InjectedConnector } from 'wagmi/connectors/injected'
+import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { WalletLinkConnector } from 'wagmi/connectors/walletLink'
+
+// Get environment variables
+const alchemyId = process.env.NEXT_PUBLIC_ALCHEMY_ID as string
+const etherscanApiKey = process.env.NEXT_PUBLIC_ETHERSCAN_API_KEY as string
+const infuraId = process.env.NEXT_PUBLIC_INFURA_ID as string
+
+// Pick chains
+const chains = defaultChains
+const defaultChain = chain.mainnet
+
+// Set up connectors
+type ConnectorsConfig = { chainId?: number }
+const connectors = ({ chainId }: ConnectorsConfig) => {
+  const rpcUrl =
+    chains.find((x) => x.id === chainId)?.rpcUrls?.[0] ??
+    defaultChain.rpcUrls[0]
+  return [
+    new InjectedConnector({ chains, options: { shimDisconnect: true } }),
+    new WalletConnectConnector({
+      chains,
+      options: {
+        infuraId,
+        qrcode: true,
+      },
+    }),
+    new WalletLinkConnector({
+      chains,
+      options: {
+        appName: 'wagmi',
+        jsonRpcUrl: `${rpcUrl}/${infuraId}`,
+      },
+    }),
+  ]
+}
+
+// Set up providers
+type ProviderConfig = { chainId?: number; connector?: Connector }
+const isChainSupported = (chainId?: number) =>
+  chains.some((x) => x.id === chainId)
+
+const provider = ({ chainId }: ProviderConfig) =>
+  providers.getDefaultProvider(
+    isChainSupported(chainId) ? chainId : defaultChain.id,
+    {
+      alchemy: alchemyId,
+      etherscan: etherscanApiKey,
+      infura: infuraId,
+    },
+  )
+const webSocketProvider = ({ chainId }: ProviderConfig) =>
+  isChainSupported(chainId)
+    ? new providers.InfuraWebSocketProvider(chainId, infuraId)
+    : undefined
+
+const Provider = ({ children }: { children: React.ReactNode }) => (
+  <WagmiProvider
+    autoConnect
+    connectors={connectors}
+    provider={provider}
+    webSocketProvider={webSocketProvider}
+  >
+    {children}
+  </WagmiProvider>
+)
+
+export default Provider

--- a/examples/next/src/pages/_app.tsx
+++ b/examples/next/src/pages/_app.tsx
@@ -1,81 +1,16 @@
 import * as React from 'react'
 import type { AppProps } from 'next/app'
-import { providers } from 'ethers'
 import NextHead from 'next/head'
-
-// Imports
-import { Connector, Provider, chain, defaultChains } from 'wagmi'
-import { InjectedConnector } from 'wagmi/connectors/injected'
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
-import { WalletLinkConnector } from 'wagmi/connectors/walletLink'
-
-// Get environment variables
-const alchemyId = process.env.NEXT_PUBLIC_ALCHEMY_ID as string
-const etherscanApiKey = process.env.NEXT_PUBLIC_ETHERSCAN_API_KEY as string
-const infuraId = process.env.NEXT_PUBLIC_INFURA_ID as string
-
-// Pick chains
-const chains = defaultChains
-const defaultChain = chain.mainnet
-
-// Set up connectors
-type ConnectorsConfig = { chainId?: number }
-const connectors = ({ chainId }: ConnectorsConfig) => {
-  const rpcUrl =
-    chains.find((x) => x.id === chainId)?.rpcUrls?.[0] ??
-    defaultChain.rpcUrls[0]
-  return [
-    new InjectedConnector({ chains, options: { shimDisconnect: true } }),
-    new WalletConnectConnector({
-      chains,
-      options: {
-        infuraId,
-        qrcode: true,
-      },
-    }),
-    new WalletLinkConnector({
-      chains,
-      options: {
-        appName: 'wagmi',
-        jsonRpcUrl: `${rpcUrl}/${infuraId}`,
-      },
-    }),
-  ]
-}
-
-// Set up providers
-type ProviderConfig = { chainId?: number; connector?: Connector }
-const isChainSupported = (chainId?: number) =>
-  chains.some((x) => x.id === chainId)
-
-const provider = ({ chainId }: ProviderConfig) =>
-  providers.getDefaultProvider(
-    isChainSupported(chainId) ? chainId : defaultChain.id,
-    {
-      alchemy: alchemyId,
-      etherscan: etherscanApiKey,
-      infura: infuraId,
-    },
-  )
-const webSocketProvider = ({ chainId }: ProviderConfig) =>
-  isChainSupported(chainId)
-    ? new providers.InfuraWebSocketProvider(chainId, infuraId)
-    : undefined
 
 const App = ({ Component, pageProps }: AppProps) => {
   return (
-    <Provider
-      autoConnect
-      connectors={connectors}
-      provider={provider}
-      webSocketProvider={webSocketProvider}
-    >
+    <>
       <NextHead>
         <title>wagmi</title>
       </NextHead>
 
       <Component {...pageProps} />
-    </Provider>
+    </>
   )
 }
 

--- a/examples/next/src/pages/index.tsx
+++ b/examples/next/src/pages/index.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import { useAccount } from 'wagmi'
+import dynamic from 'next/dynamic'
 
+const Provider = dynamic(() => import('../components/Provider'))
 import { Account, Connect, NetworkSwitcher } from '../components'
 
 const Page = () => {
@@ -17,4 +19,7 @@ const Page = () => {
   return <Connect />
 }
 
-export default Page
+const withProvider = (child: React.ReactNode) => () =>
+  <Provider>{child}</Provider>
+
+export default withProvider(<Page />)


### PR DESCRIPTION
Your ENS/address: apurn.eth

I moved `Provider` away from `_app.tsx` to demonstrate how to dynamically load `wagmi`'s Provider.

This serves as an answer for https://github.com/tmm/wagmi/discussions/32.

## Improvements

Before:
<img width="569" alt="Screen Shot 2022-03-25 at 12 39 26 AM" src="https://user-images.githubusercontent.com/14824254/160077524-a55bcca8-c840-4bed-9a30-aa76b35f96d8.png">
First Load JS >300kb across all pages

After:
<img width="546" alt="Screen Shot 2022-03-25 at 12 44 17 AM" src="https://user-images.githubusercontent.com/14824254/160077602-973dfc6d-48bd-4cd4-95c0-1882e1e10d22.png">
First load JS on heaviest page (the one where we import `wagmi` without any lazy loading) = 200kb
Shared JS (~70kb) because we dynamically loaded `wagmi` AND `ethers`
