### PR TITLE
Use ES2021 as output for ESNext breaks some recent browsers

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "ESNEXT"
+    "target": "ES2021"
   },
   "exclude": ["node_modules", "**/dist/**"],
   "include": ["packages/**/*"]


### PR DESCRIPTION
Safari doesn't support private class fields natively until 14.4. This means that anyone on iOS on a version less than that will have a broken experience. This changes the target output to use ES2021 this should transpile the minimum amount of features needed to have this still work in modern-ish browsers. In the interests of keeping Web3 accessible to folk who dont have the latest devices of OS's I think we should introduce a small amount of transpilation for a bigger support.

This fixes #288 

Your ENS/address: sammdec.eth
