### PR TITLE
fix: private fields

### DIFF
--- a/.changeset/big-dodos-ring.md
+++ b/.changeset/big-dodos-ring.md
@@ -1,0 +1,7 @@
+---
+'wagmi-core': patch
+'wagmi': patch
+'wagmi-testing': patch
+---
+
+fix private fields

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,7 +3,7 @@ module.exports = {
 
   overrides: [
     {
-      include: ['./packages/private', './packages/react'],
+      include: ['./packages/core', './packages/react'],
       presets: [['@babel/preset-env', { targets: { esmodules: true } }]],
     },
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "ES2021"
+    "target": "es2021"
   },
   "exclude": ["node_modules", "**/dist/**"],
   "include": ["packages/**/*"]


### PR DESCRIPTION
Missed updating babel config when `wagmi-private` was renamed `wagmi-core`.