### PR TITLE
fix: fix exposing global types

### DIFF
--- a/packages/core/src/types/declarations.d.ts
+++ b/packages/core/src/types/declarations.d.ts
@@ -1,52 +1,54 @@
-type AddEthereumChainParameter = {
-  chainId: string // A 0x-prefixed hexadecimal string
-  chainName: string
-  nativeCurrency?: {
-    name: string
-    symbol: string // 2-6 characters long
-    decimals: 18
+export declare global {
+  type AddEthereumChainParameter = {
+    chainId: string // A 0x-prefixed hexadecimal string
+    chainName: string
+    nativeCurrency?: {
+      name: string
+      symbol: string // 2-6 characters long
+      decimals: 18
+    }
+    rpcUrls: string[]
+    blockExplorerUrls?: string[]
+    iconUrls?: string[] // Currently ignored.
   }
-  rpcUrls: string[]
-  blockExplorerUrls?: string[]
-  iconUrls?: string[] // Currently ignored.
-}
 
-type WatchAssetParams = {
-  type: 'ERC20' // In the future, other standards will be supported
-  options: {
-    address: string // The address of the token contract
-    decimals: number // The number of token decimals
-    image?: string // A string url of the token logo
-    symbol: string // A ticker symbol or shorthand, up to 5 characters
+  type WatchAssetParams = {
+    type: 'ERC20' // In the future, other standards will be supported
+    options: {
+      address: string // The address of the token contract
+      decimals: number // The number of token decimals
+      image?: string // A string url of the token logo
+      symbol: string // A ticker symbol or shorthand, up to 5 characters
+    }
   }
-}
 
-type RequestArguments =
-  | { method: 'eth_accounts' }
-  | { method: 'eth_chainId' }
-  | { method: 'eth_requestAccounts' }
-  | { method: 'personal_sign'; params: [string, string] }
-  | { method: 'wallet_addEthereumChain'; params: AddEthereumChainParameter[] }
-  | { method: 'wallet_switchEthereumChain'; params: [{ chainId: string }] }
-  | { method: 'wallet_watchAsset'; params: WatchAssetParams }
+  type RequestArguments =
+    | { method: 'eth_accounts' }
+    | { method: 'eth_chainId' }
+    | { method: 'eth_requestAccounts' }
+    | { method: 'personal_sign'; params: [string, string] }
+    | { method: 'wallet_addEthereumChain'; params: AddEthereumChainParameter[] }
+    | { method: 'wallet_switchEthereumChain'; params: [{ chainId: string }] }
+    | { method: 'wallet_watchAsset'; params: WatchAssetParams }
 
-type InjectedProviders = {
-  isCoinbaseWallet?: true
-  isFrame?: true
-  isMetaMask?: true
-  isTally?: true
-}
-
-interface Window {
-  ethereum?: InjectedProviders & {
-    on?: (...args: any[]) => void
-    removeListener?: (...args: any[]) => void
-    request<T = any>(args: RequestArguments): Promise<T>
+  type InjectedProviders = {
+    isCoinbaseWallet?: true
+    isFrame?: true
+    isMetaMask?: true
+    isTally?: true
   }
-}
 
-interface ProviderRpcError extends Error {
-  code: 4001 | 4902
-  data?: unknown
-  message: string
+  interface Window {
+    ethereum?: InjectedProviders & {
+      on?: (...args: any[]) => void
+      removeListener?: (...args: any[]) => void
+      request<T = any>(args: RequestArguments): Promise<T>
+    }
+  }
+
+  interface ProviderRpcError extends Error {
+    code: 4001 | 4902
+    data?: unknown
+    message: string
+  }
 }


### PR DESCRIPTION
## Issue
Let's say I need to override `ethereum` object in window. I need to create `global.d.ts` and put something like:

```ts
export declare global {
  interface Window {
    ethereum: any,
  }
}
```

Currently it is impossible, because types are not declared properly and they override my overriding. 
I created repository with an example https://github.com/cawabunga/wagmi-window-error-example

## References
- Typescript Doc https://www.typescriptlang.org/docs/handbook/declaration-merging.html#global-augmentation
- Example https://github.com/cawabunga/wagmi-window-error-example

## Implementation
The PR doesn't break backward capability. All types are exposed to global scope (I think by mistake), so PR keeps this behaviour as well. The PR just allows to override exposed interfaces.