### PR TITLE
feat: add Brave Wallet detection

### DIFF
--- a/packages/core/src/types/declarations.d.ts
+++ b/packages/core/src/types/declarations.d.ts
@@ -31,6 +31,7 @@ type RequestArguments =
   | { method: 'wallet_watchAsset'; params: WatchAssetParams }
 
 type InjectedProviders = {
+  isBraveWallet?: true
   isCoinbaseWallet?: true
   isFrame?: true
   isMetaMask?: true

--- a/packages/core/src/utils/getInjectedName.test.ts
+++ b/packages/core/src/utils/getInjectedName.test.ts
@@ -3,6 +3,7 @@ import { getInjectedName } from './getInjectedName'
 describe.each`
   ethereum                      | expected
   ${undefined}                  | ${'Injected'}
+  ${{ isBraveWallet: true }}    | ${'Brave Wallet'}
   ${{ isMetaMask: true }}       | ${'MetaMask'}
   ${{ isCoinbaseWallet: true }} | ${'Coinbase Wallet'}
   ${{ isFrame: true }}          | ${'Frame'}

--- a/packages/core/src/utils/getInjectedName.ts
+++ b/packages/core/src/utils/getInjectedName.ts
@@ -1,5 +1,6 @@
 export const getInjectedName = (ethereum?: Window['ethereum']) => {
   if (!ethereum) return 'Injected'
+  if (ethereum.isBraveWallet) return 'Brave Wallet'
   if (ethereum.isMetaMask) return 'MetaMask'
   if (ethereum.isCoinbaseWallet) return 'Coinbase Wallet'
   if (ethereum.isFrame) return 'Frame'


### PR DESCRIPTION
Adds the ability to detect if Brave Wallet is the currently injected web3 provider.

ENS/address: 0x46A628fF77afe9864dc8A4Fb34AB16f60F6733da
