### PR TITLE
Changed 'networkData' variable to 'data'

### DIFF
--- a/docs/pages/docs/hooks/useNetwork.mdx
+++ b/docs/pages/docs/hooks/useNetwork.mdx
@@ -19,7 +19,7 @@ const App = () => {
   return (
     <>
       <div>
-        {data.chain?.name ?? networkData.chain?.id}{' '}
+        {data.chain?.name ?? data.chain?.id}{' '}
         {data.chain?.unsupported && '(unsupported)'}
       </div>
 


### PR DESCRIPTION
`networkData` isn't defined, and so it throws and error. I assume it's not `networkData` but the `data` variable that you want to use.

Your ENS/address: 0xE4E6dC19efd564587C46dCa2ED787e45De17E7E1
