### PR TITLE
refactor: remove signerOrProvider option from read contract

### DIFF
--- a/packages/core/src/actions/contracts/readContract.ts
+++ b/packages/core/src/actions/contracts/readContract.ts
@@ -4,7 +4,10 @@ import { Result } from 'ethers/lib/utils'
 import { getProvider } from '../providers'
 import { GetContractArgs, getContract } from './getContract'
 
-export type ReadContractArgs = GetContractArgs
+export type ReadContractArgs = Pick<
+  GetContractArgs,
+  'addressOrName' | 'contractInterface'
+>
 export type ReadContractConfig = {
   /** Arguments to pass contract method */
   args?: any | any[]

--- a/packages/react/src/hooks/contracts/useContractRead.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.ts
@@ -99,9 +99,7 @@ export function useContractRead(
 
   const enabled = React.useMemo(() => {
     let enabled = Boolean(enabled_ && contractConfig && functionName)
-    if (cacheOnBlock) {
-      enabled = Boolean(enabled && blockNumber)
-    }
+    if (cacheOnBlock) enabled = Boolean(enabled && blockNumber)
     return enabled
   }, [blockNumber, cacheOnBlock, contractConfig, enabled_, functionName])
 


### PR DESCRIPTION
## Description

`signerOrProvider` is difficult to serialize and conflicts with other configuration, like `chainId`.

Fixes #367 

## Additional Information

- [x] I read the contributing docs (if this is your first contribution)

Your ENS/address: awkweb.eth
