### PR TITLE
docs: ✏️ Added optional chaining

### DIFF
--- a/docs/pages/docs/hooks/useConnect.en-US.mdx
+++ b/docs/pages/docs/hooks/useConnect.en-US.mdx
@@ -28,7 +28,7 @@ function App() {
       {connectors.map((x) => (
         <button disabled={!x.ready} key={x.id} onClick={() => connect(x)}>
           {x.name}
-          {isConnecting && pendingConnector.id === x.id && ' (connecting)'}
+          {isConnecting && pendingConnector?.id === x.id && ' (connecting)'}
         </button>
       ))}
 


### PR DESCRIPTION
Added option chainging to pendingConnector to do it possibly being null

## Description

Updated the docs based on TypeScript recommendation, made `pendingConnector.id` optional because it could potentially be null.

<img width="684" alt="Screen Shot 2022-05-01 at 8 42 33 AM" src="https://user-images.githubusercontent.com/318082/166146500-cfdf3dda-b866-4524-9e2b-73a56e3b99ea.png">

**Main change in docs:**

```diff
- pendingConnector.id
+ pendingConnector?.id
```

## Additional Information

- [x] I read the contributing docs (if this is your first contribution)

Your ENS/address:

codingwithmanny.eth
