### PR TITLE
Store/expose caught errors before rethrowing

### DIFF
--- a/packages/core/src/actions/accounts/signMessage.ts
+++ b/packages/core/src/actions/accounts/signMessage.ts
@@ -21,7 +21,7 @@ export async function signMessage(
   } catch (error_) {
     let error: Error = <Error>error_
     if ((<ProviderRpcError>error_).code === 4001)
-      error = new UserRejectedRequestError()
+      error = new UserRejectedRequestError(error_)
     throw error
   }
 }

--- a/packages/core/src/actions/accounts/signTypedData.ts
+++ b/packages/core/src/actions/accounts/signTypedData.ts
@@ -31,7 +31,7 @@ export async function signTypedData(
   } catch (error_) {
     let error: Error = <Error>error_
     if ((<ProviderRpcError>error_).code === 4001)
-      error = new UserRejectedRequestError()
+      error = new UserRejectedRequestError(error)
     throw error
   }
 }

--- a/packages/core/src/actions/contracts/writeContract.ts
+++ b/packages/core/src/actions/contracts/writeContract.ts
@@ -44,7 +44,7 @@ export async function writeContract<
   } catch (error_) {
     let error: Error = <Error>error_
     if ((<ProviderRpcError>error_).code === 4001)
-      error = new UserRejectedRequestError()
+      error = new UserRejectedRequestError(error_)
     throw error
   }
 }

--- a/packages/core/src/actions/transactions/sendTransaction.ts
+++ b/packages/core/src/actions/transactions/sendTransaction.ts
@@ -25,7 +25,7 @@ export async function sendTransaction(
   } catch (error_) {
     let error: Error = <Error>error_
     if ((<ProviderRpcError>error_).code === 4001)
-      error = new UserRejectedRequestError()
+      error = new UserRejectedRequestError(error_)
     throw error
   }
 }

--- a/packages/core/src/connectors/coinbaseWallet.ts
+++ b/packages/core/src/connectors/coinbaseWallet.ts
@@ -72,7 +72,7 @@ export class CoinbaseWalletConnector extends Connector<
           (<ProviderRpcError>error).message,
         )
       )
-        throw new UserRejectedRequestError()
+        throw new UserRejectedRequestError(error)
       throw error
     }
   }
@@ -166,7 +166,7 @@ export class CoinbaseWalletConnector extends Connector<
       if ((<ProviderRpcError>error).code === 4902) {
         try {
           const chain = this.chains.find((x) => x.id === chainId)
-          if (!chain) throw new ChainNotConfiguredError()
+          if (!chain) throw new ChainNotConfiguredError(error)
           await provider.request({
             method: 'wallet_addEthereumChain',
             params: [
@@ -181,11 +181,11 @@ export class CoinbaseWalletConnector extends Connector<
           })
           return chain
         } catch (addError) {
-          throw new AddChainError()
+          throw new AddChainError(addError)
         }
       } else if ((<ProviderRpcError>error).code === 4001)
-        throw new UserRejectedRequestError()
-      else throw new SwitchChainError()
+        throw new UserRejectedRequestError(error)
+      else throw new SwitchChainError(error)
     }
   }
 

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -84,7 +84,7 @@ export class InjectedConnector extends Connector<
       return { account, chain: { id, unsupported }, provider }
     } catch (error) {
       if ((<ProviderRpcError>error).code === 4001)
-        throw new UserRejectedRequestError()
+        throw new UserRejectedRequestError(error)
       throw error
     }
   }
@@ -177,7 +177,7 @@ export class InjectedConnector extends Connector<
       if ((<ProviderRpcError>error).code === 4902) {
         try {
           const chain = this.chains.find((x) => x.id === chainId)
-          if (!chain) throw new ChainNotConfiguredError()
+          if (!chain) throw new ChainNotConfiguredError(error)
           await provider.request({
             method: 'wallet_addEthereumChain',
             params: [
@@ -192,11 +192,11 @@ export class InjectedConnector extends Connector<
           })
           return chain
         } catch (addError) {
-          throw new AddChainError()
+          throw new AddChainError(addError)
         }
       } else if ((<ProviderRpcError>error).code === 4001)
-        throw new UserRejectedRequestError()
-      else throw new SwitchChainError()
+        throw new UserRejectedRequestError(error)
+      else throw new SwitchChainError(error)
     }
   }
 

--- a/packages/core/src/connectors/mock/provider.ts
+++ b/packages/core/src/connectors/mock/provider.ts
@@ -36,7 +36,8 @@ export class MockProvider extends providers.BaseProvider {
   }
 
   async enable() {
-    if (this.#options.flags?.failConnect) throw new UserRejectedRequestError()
+    if (this.#options.flags?.failConnect)
+      throw new UserRejectedRequestError(undefined)
     if (!this.#signer) this.#signer = this.#options.signer
     const address = await this.#signer.getAddress()
     this.events.emit('accountsChanged', [address])
@@ -62,7 +63,7 @@ export class MockProvider extends providers.BaseProvider {
 
   async switchChain(chainId: number) {
     if (this.#options.flags?.failSwitchChain)
-      throw new UserRejectedRequestError()
+      throw new UserRejectedRequestError(undefined)
     this.#options.network = chainId
     this.network.chainId = chainId
     this.events.emit('chainChanged', chainId)

--- a/packages/core/src/connectors/walletConnect.ts
+++ b/packages/core/src/connectors/walletConnect.ts
@@ -57,7 +57,7 @@ export class WalletConnectConnector extends Connector<
       }
     } catch (error) {
       if (/user closed modal/i.test((<ProviderRpcError>error).message))
-        throw new UserRejectedRequestError()
+        throw new UserRejectedRequestError(error)
       throw error
     }
   }

--- a/packages/core/src/connectors/walletConnect.ts
+++ b/packages/core/src/connectors/walletConnect.ts
@@ -137,8 +137,8 @@ export class WalletConnectConnector extends Connector<
       const message =
         typeof error === 'string' ? error : (<ProviderRpcError>error)?.message
       if (/user rejected request/i.test(message))
-        throw new UserRejectedRequestError()
-      else throw new SwitchChainError()
+        throw new UserRejectedRequestError(error)
+      else throw new SwitchChainError(error)
     }
   }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,12 +1,10 @@
 export class WrappedError extends Error {
   // The original error from the catch block before rethrowing
-  readonly originalError: Error | undefined
+  readonly originalError: unknown
 
   constructor(originalError: unknown) {
     super()
-    if (originalError instanceof Error) {
-      this.originalError = originalError
-    }
+    this.originalError = originalError
   }
 }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,8 +1,8 @@
-export class WagmiError extends Error {
+export class WrappedError extends Error {
   // The original error from the catch block before rethrowing
   readonly originalError: Error | undefined
 
-  constructor(originalError?: unknown) {
+  constructor(originalError: unknown) {
     super()
     if (originalError instanceof Error) {
       this.originalError = originalError
@@ -10,37 +10,37 @@ export class WagmiError extends Error {
   }
 }
 
-export class AddChainError extends WagmiError {
+export class AddChainError extends Error {
   name = 'AddChainError'
   message = 'Error adding chain'
 }
 
-export class ChainNotConfiguredError extends WagmiError {
+export class ChainNotConfiguredError extends Error {
   name = 'ChainNotConfigured'
   message = 'Chain not configured'
 }
 
-export class ConnectorAlreadyConnectedError extends WagmiError {
+export class ConnectorAlreadyConnectedError extends Error {
   name = 'ConnectorAlreadyConnectedError'
   message = 'Connector already connected'
 }
 
-export class ConnectorNotFoundError extends WagmiError {
+export class ConnectorNotFoundError extends Error {
   name = 'ConnectorNotFoundError'
   message = 'Connector not found'
 }
 
-export class SwitchChainError extends WagmiError {
+export class SwitchChainError extends WrappedError {
   name = 'SwitchChainError'
   message = 'Error switching chain'
 }
 
-export class SwitchChainNotSupportedError extends WagmiError {
+export class SwitchChainNotSupportedError extends Error {
   name = 'SwitchChainNotSupportedError'
   message = 'Switch chain not supported by connector'
 }
 
-export class UserRejectedRequestError extends WagmiError {
+export class UserRejectedRequestError extends WrappedError {
   name = 'UserRejectedRequestError'
   message = 'User rejected request'
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,34 +1,46 @@
-export class AddChainError extends Error {
+export class WagmiError extends Error {
+  // The original error from the catch block before rethrowing
+  readonly originalError: Error | undefined
+
+  constructor(originalError?: unknown) {
+    super()
+    if (originalError instanceof Error) {
+      this.originalError = originalError
+    }
+  }
+}
+
+export class AddChainError extends WagmiError {
   name = 'AddChainError'
   message = 'Error adding chain'
 }
 
-export class ChainNotConfiguredError extends Error {
+export class ChainNotConfiguredError extends WagmiError {
   name = 'ChainNotConfigured'
   message = 'Chain not configured'
 }
 
-export class ConnectorAlreadyConnectedError extends Error {
+export class ConnectorAlreadyConnectedError extends WagmiError {
   name = 'ConnectorAlreadyConnectedError'
   message = 'Connector already connected'
 }
 
-export class ConnectorNotFoundError extends Error {
+export class ConnectorNotFoundError extends WagmiError {
   name = 'ConnectorNotFoundError'
   message = 'Connector not found'
 }
 
-export class SwitchChainError extends Error {
+export class SwitchChainError extends WagmiError {
   name = 'SwitchChainError'
   message = 'Error switching chain'
 }
 
-export class SwitchChainNotSupportedError extends Error {
+export class SwitchChainNotSupportedError extends WagmiError {
   name = 'SwitchChainNotSupportedError'
   message = 'Switch chain not supported by connector'
 }
 
-export class UserRejectedRequestError extends Error {
+export class UserRejectedRequestError extends WagmiError {
   name = 'UserRejectedRequestError'
   message = 'User rejected request'
 }


### PR DESCRIPTION
## Description

Store/expose caught errors before rethrowing custom wagmi-specific errors.

Motivation: I wanted to dive deeper into why Rainbow was throwing a "switch chain error" when calling switch chain and realized I didn't have access to the originally thrown error, which might have more hints as to what's going on.

I initially extended ~all of the custom wagmi errors, but found only a subset were used in try/catch blocks, so ended up only wrapping those. There are a couple places in mocks where we pass an `undefined` argument, which is a little gross, but the argument type safety seemed nice to have in all other spots.

## Additional Information

- [x] I read the contributing docs (if this is your first contribution)

Your ENS/address:
frolic.eth