### PR TITLE
Fix/missed import in the Connect wallet example

### DIFF
--- a/docs/pages/examples/connect-wallet.en-US.mdx
+++ b/docs/pages/examples/connect-wallet.en-US.mdx
@@ -13,7 +13,7 @@ The example below uses [`useConnect`](/docs/hooks/useConnect), [`useAccount`](/d
 First, we create a new wagmi client set up with the Injected (i.e. MetaMask), WalletConnect, and Coinbase Wallet connectors:
 
 ```tsx
-import { Provider, chain, createClient } from 'wagmi'
+import { Provider, chain, createClient, defaultChains } from 'wagmi'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'


### PR DESCRIPTION
## Description

Hi, guys. Your project looks awesome. When I started setting up connector configurations, I noticed that you left out the import in one of the examples.

```tsx
import { defaultChains } from 'wagmi';
```

