### PR TITLE
fix: use ethers peer dependency for providers

### DIFF
--- a/packages/core/src/actions/accounts/connect.ts
+++ b/packages/core/src/actions/accounts/connect.ts
@@ -1,4 +1,4 @@
-import type { BaseProvider } from '@ethersproject/providers'
+import { providers } from 'ethers'
 
 import { Client, client } from '../../client'
 import { Connector, ConnectorData } from '../../connectors'
@@ -9,18 +9,19 @@ export type ConnectArgs = {
   connector: Connector
 }
 
-type Data<TProvider extends BaseProvider = BaseProvider> = Required<
-  ConnectorData<TProvider>
->
+type Data<TProvider extends providers.BaseProvider = providers.BaseProvider> =
+  Required<ConnectorData<TProvider>>
 
-export type ConnectResult<TProvider extends BaseProvider = BaseProvider> = {
+export type ConnectResult<
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
+> = {
   account: Data<TProvider>['account']
   chain: Data<TProvider>['chain']
   connector: Client<TProvider>['connector']
   provider: Data<TProvider>['provider']
 }
 
-export async function connect<TProvider extends BaseProvider>({
+export async function connect<TProvider extends providers.BaseProvider>({
   connector,
 }: ConnectArgs): Promise<ConnectResult<TProvider>> {
   const activeConnector = client.connector

--- a/packages/core/src/actions/accounts/getAccount.ts
+++ b/packages/core/src/actions/accounts/getAccount.ts
@@ -1,14 +1,16 @@
-import type { BaseProvider } from '@ethersproject/providers'
+import { providers } from 'ethers'
 
 import { Client, Data, getClient } from '../../client'
 
-export type GetAccountResult<TProvider extends BaseProvider = BaseProvider> = {
+export type GetAccountResult<
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
+> = {
   address?: Data<TProvider>['account']
   connector?: Client<TProvider>['connector']
 }
 
 export function getAccount<
-  TProvider extends BaseProvider,
+  TProvider extends providers.BaseProvider,
 >(): GetAccountResult<TProvider> {
   const { data, connector } = getClient()
   return {

--- a/packages/core/src/actions/accounts/watchAccount.ts
+++ b/packages/core/src/actions/accounts/watchAccount.ts
@@ -1,13 +1,13 @@
-import type { BaseProvider } from '@ethersproject/providers'
+import { providers } from 'ethers'
 
 import { getClient } from '../../client'
 import { GetAccountResult, getAccount } from './getAccount'
 
 export type WatchAccountCallback<
-  TProvider extends BaseProvider = BaseProvider,
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
 > = (data: GetAccountResult<TProvider>) => void
 
-export function watchAccount<TProvider extends BaseProvider>(
+export function watchAccount<TProvider extends providers.BaseProvider>(
   callback: WatchAccountCallback<TProvider>,
 ) {
   const client = getClient()

--- a/packages/core/src/actions/contracts/getContract.ts
+++ b/packages/core/src/actions/contracts/getContract.ts
@@ -1,5 +1,4 @@
-import type { Provider } from '@ethersproject/providers'
-import { Contract, ContractInterface, Signer } from 'ethers/lib/ethers'
+import { Contract, ContractInterface, Signer, providers } from 'ethers'
 
 export type GetContractArgs = {
   /** Contract address or ENS name */
@@ -7,7 +6,7 @@ export type GetContractArgs = {
   /** Contract interface or ABI */
   contractInterface: ContractInterface
   /** Signer or provider to attach to contract */
-  signerOrProvider?: Signer | Provider | null
+  signerOrProvider?: Signer | providers.Provider | null
 }
 
 export function getContract<T = Contract>({
@@ -20,7 +19,7 @@ export function getContract<T = Contract>({
       new Contract(
         addressOrName,
         contractInterface,
-        <Signer | Provider | undefined>signerOrProvider,
+        <Signer | providers.Provider | undefined>signerOrProvider,
       )
     ))
   )

--- a/packages/core/src/actions/contracts/writeContract.ts
+++ b/packages/core/src/actions/contracts/writeContract.ts
@@ -1,5 +1,4 @@
-import type { TransactionResponse } from '@ethersproject/providers'
-import { CallOverrides, Contract as EthersContract } from 'ethers/lib/ethers'
+import { CallOverrides, Contract as EthersContract, providers } from 'ethers'
 
 import { getClient } from '../../client'
 import { ConnectorNotFoundError, UserRejectedRequestError } from '../../errors'
@@ -13,7 +12,7 @@ export type WriteContractConfig = {
   overrides?: CallOverrides
 }
 
-export type WriteContractResult = TransactionResponse
+export type WriteContractResult = providers.TransactionResponse
 
 export async function writeContract<
   Contract extends EthersContract = EthersContract,
@@ -39,7 +38,9 @@ export async function writeContract<
       console.warn(
         `"${functionName}" does not in interface for contract "${contractConfig.addressOrName}"`,
       )
-    const response = (await contractFunction(...params)) as TransactionResponse
+    const response = (await contractFunction(
+      ...params,
+    )) as providers.TransactionResponse
     return response
   } catch (error_) {
     let error: Error = <Error>error_

--- a/packages/core/src/actions/ens/fetchEnsResolver.ts
+++ b/packages/core/src/actions/ens/fetchEnsResolver.ts
@@ -1,4 +1,4 @@
-import type { Resolver } from '@ethersproject/providers'
+import { providers } from 'ethers'
 
 import { getProvider } from '../providers'
 
@@ -9,7 +9,7 @@ export type FetchEnsResolverArgs = {
   name: string
 }
 
-export type FetchEnsResolverResult = Resolver | null
+export type FetchEnsResolverResult = providers.Resolver | null
 
 export async function fetchEnsResolver({
   chainId,

--- a/packages/core/src/actions/network-status/fetchFeeData.ts
+++ b/packages/core/src/actions/network-status/fetchFeeData.ts
@@ -1,5 +1,4 @@
-import type { FeeData } from '@ethersproject/providers'
-import { BigNumberish } from 'ethers/lib/ethers'
+import { BigNumberish, providers } from 'ethers'
 import { formatUnits } from 'ethers/lib/utils'
 
 import { Unit } from '../../types'
@@ -12,7 +11,7 @@ export type FetchFeeDataArgs = {
   chainId?: number
 }
 
-export type FetchFeeDataResult = FeeData & {
+export type FetchFeeDataResult = providers.FeeData & {
   formatted: {
     gasPrice: string
     maxFeePerGas: string

--- a/packages/core/src/actions/network-status/watchBlockNumber.ts
+++ b/packages/core/src/actions/network-status/watchBlockNumber.ts
@@ -1,4 +1,4 @@
-import type { BaseProvider } from '@ethersproject/providers'
+import { providers } from 'ethers'
 
 import { getClient } from '../../client'
 import { FetchBlockNumberResult, fetchBlockNumber } from './fetchBlockNumber'
@@ -12,8 +12,8 @@ export function watchBlockNumber(
   args: WatchBlockNumberArgs,
   callback: WatchBlockNumberCallback,
 ) {
-  let prevProvider: BaseProvider
-  const createListener = (provider: BaseProvider) => {
+  let prevProvider: providers.BaseProvider
+  const createListener = (provider: providers.BaseProvider) => {
     if (prevProvider) {
       prevProvider?.off('block', callback)
     }

--- a/packages/core/src/actions/providers/getProvider.ts
+++ b/packages/core/src/actions/providers/getProvider.ts
@@ -1,4 +1,4 @@
-import type { BaseProvider } from '@ethersproject/providers'
+import { providers } from 'ethers'
 
 import { getClient } from '../../client'
 
@@ -7,12 +7,13 @@ export type GetProviderArgs = {
   chainId?: number
 }
 
-export type GetProviderResult<TProvider extends BaseProvider = BaseProvider> =
-  TProvider
+export type GetProviderResult<
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
+> = TProvider
 
-export function getProvider<TProvider extends BaseProvider = BaseProvider>({
-  chainId,
-}: GetProviderArgs = {}): GetProviderResult<TProvider> {
+export function getProvider<
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
+>({ chainId }: GetProviderArgs = {}): GetProviderResult<TProvider> {
   const client = getClient<TProvider>()
   if (chainId && typeof client.config.provider === 'function')
     return client.config.provider({ chainId })

--- a/packages/core/src/actions/providers/getWebSocketProvider.ts
+++ b/packages/core/src/actions/providers/getWebSocketProvider.ts
@@ -1,4 +1,4 @@
-import type { WebSocketProvider } from '@ethersproject/providers'
+import { providers } from 'ethers'
 
 import { getClient } from '../../client'
 
@@ -8,11 +8,11 @@ export type GetWebSocketProviderArgs = {
 }
 
 export type GetWebSocketProviderResult<
-  TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TWebSocketProvider extends providers.WebSocketProvider = providers.WebSocketProvider,
 > = TWebSocketProvider | undefined
 
 export function getWebSocketProvider<
-  TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TWebSocketProvider extends providers.WebSocketProvider = providers.WebSocketProvider,
 >({
   chainId,
 }: GetWebSocketProviderArgs = {}): GetWebSocketProviderResult<TWebSocketProvider> {

--- a/packages/core/src/actions/providers/watchProvider.ts
+++ b/packages/core/src/actions/providers/watchProvider.ts
@@ -1,16 +1,15 @@
-import type { BaseProvider } from '@ethersproject/providers'
+import { providers } from 'ethers'
 
 import { getClient } from '../../client'
 import { GetProviderArgs, GetProviderResult, getProvider } from './getProvider'
 
 export type WatchProviderCallback<
-  TProvider extends BaseProvider = BaseProvider,
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
 > = (provider: GetProviderResult<TProvider>) => void
 
-export function watchProvider<TProvider extends BaseProvider = BaseProvider>(
-  args: GetProviderArgs,
-  callback: WatchProviderCallback<TProvider>,
-) {
+export function watchProvider<
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
+>(args: GetProviderArgs, callback: WatchProviderCallback<TProvider>) {
   const client = getClient()
   const handleChange = async () => callback(getProvider<TProvider>(args))
   const unsubscribe = client.subscribe(({ provider }) => provider, handleChange)

--- a/packages/core/src/actions/providers/watchWebSocketProvider.ts
+++ b/packages/core/src/actions/providers/watchWebSocketProvider.ts
@@ -1,4 +1,4 @@
-import type { WebSocketProvider } from '@ethersproject/providers'
+import { providers } from 'ethers'
 
 import { getClient } from '../../client'
 import {
@@ -8,11 +8,11 @@ import {
 } from './getWebSocketProvider'
 
 export type WatchWebSocketProviderCallback<
-  TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TWebSocketProvider extends providers.WebSocketProvider = providers.WebSocketProvider,
 > = (webSocketProvider: GetWebSocketProviderResult<TWebSocketProvider>) => void
 
 export function watchWebSocketProvider<
-  TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TWebSocketProvider extends providers.WebSocketProvider = providers.WebSocketProvider,
 >(
   args: GetWebSocketProviderArgs,
   callback: WatchWebSocketProviderCallback<TWebSocketProvider>,

--- a/packages/core/src/actions/transactions/sendTransaction.ts
+++ b/packages/core/src/actions/transactions/sendTransaction.ts
@@ -1,17 +1,14 @@
-import type {
-  TransactionRequest,
-  TransactionResponse,
-} from '@ethersproject/providers'
+import { providers } from 'ethers'
 
 import { ConnectorNotFoundError, UserRejectedRequestError } from '../../errors'
 import { fetchSigner } from '../accounts'
 
 export type SendTransactionArgs = {
   /** Object to use when creating transaction */
-  request: TransactionRequest
+  request: providers.TransactionRequest
 }
 
-export type SendTransactionResult = TransactionResponse
+export type SendTransactionResult = providers.TransactionResponse
 
 export async function sendTransaction(
   args: SendTransactionArgs,

--- a/packages/core/src/actions/transactions/waitForTransaction.ts
+++ b/packages/core/src/actions/transactions/waitForTransaction.ts
@@ -1,7 +1,4 @@
-import type {
-  TransactionReceipt,
-  TransactionResponse,
-} from '@ethersproject/providers'
+import { providers } from 'ethers'
 
 import { getProvider } from '../providers'
 
@@ -21,10 +18,10 @@ export type WaitForTransactionArgs = {
    */
   timeout?: number
   /** Function resolving to transaction receipt */
-  wait?: TransactionResponse['wait']
+  wait?: providers.TransactionResponse['wait']
 }
 
-export type WaitForTransactionResult = TransactionReceipt
+export type WaitForTransactionResult = providers.TransactionReceipt
 
 export async function waitForTransaction({
   chainId,
@@ -33,7 +30,7 @@ export async function waitForTransaction({
   timeout,
   wait: wait_,
 }: WaitForTransactionArgs): Promise<WaitForTransactionResult> {
-  let promise: Promise<TransactionReceipt>
+  let promise: Promise<providers.TransactionReceipt>
   if (hash) {
     const provider = getProvider({ chainId })
     promise = provider.waitForTransaction(hash, confirmations, timeout)

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1,5 +1,4 @@
-import type { BaseProvider, WebSocketProvider } from '@ethersproject/providers'
-import { getDefaultProvider } from 'ethers'
+import { getDefaultProvider, providers } from 'ethers'
 import { Mutate, StoreApi, default as create } from 'zustand/vanilla'
 import { persist, subscribeWithSelector } from 'zustand/middleware'
 
@@ -8,8 +7,8 @@ import { WagmiStorage, createStorage, noopStorage } from './storage'
 import { warn } from './utils'
 
 export type ClientConfig<
-  TProvider extends BaseProvider = BaseProvider,
-  TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
+  TWebSocketProvider extends providers.WebSocketProvider = providers.WebSocketProvider,
 > = {
   /** Enables reconnecting to last used connector on init */
   autoConnect?: boolean
@@ -34,10 +33,11 @@ export type ClientConfig<
     | TWebSocketProvider
 }
 
-export type Data<TProvider extends BaseProvider> = ConnectorData<TProvider>
+export type Data<TProvider extends providers.BaseProvider> =
+  ConnectorData<TProvider>
 export type State<
-  TProvider extends BaseProvider,
-  TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TProvider extends providers.BaseProvider,
+  TWebSocketProvider extends providers.WebSocketProvider = providers.WebSocketProvider,
 > = {
   chains?: Connector['chains']
   connector?: Connector
@@ -52,8 +52,8 @@ export type State<
 const storeKey = 'store'
 
 export class Client<
-  TProvider extends BaseProvider = BaseProvider,
-  TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
+  TWebSocketProvider extends providers.WebSocketProvider = providers.WebSocketProvider,
 > {
   config: Partial<ClientConfig<TProvider, TWebSocketProvider>>
   storage: WagmiStorage
@@ -302,20 +302,23 @@ export class Client<
   }
 }
 
-export let client: Client<BaseProvider, WebSocketProvider>
+export let client: Client<providers.BaseProvider, providers.WebSocketProvider>
 
 export function createClient<
-  TProvider extends BaseProvider = BaseProvider,
-  TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
+  TWebSocketProvider extends providers.WebSocketProvider = providers.WebSocketProvider,
 >(config?: ClientConfig<TProvider, TWebSocketProvider>) {
   const client_ = new Client<TProvider, TWebSocketProvider>(config)
-  client = client_ as unknown as Client<BaseProvider, WebSocketProvider>
+  client = client_ as unknown as Client<
+    providers.BaseProvider,
+    providers.WebSocketProvider
+  >
   return client_
 }
 
 export function getClient<
-  TProvider extends BaseProvider = BaseProvider,
-  TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
+  TWebSocketProvider extends providers.WebSocketProvider = providers.WebSocketProvider,
 >() {
   if (!client) {
     warn('No client defined. Falling back to default client.')

--- a/packages/core/src/connectors/coinbaseWallet.ts
+++ b/packages/core/src/connectors/coinbaseWallet.ts
@@ -1,4 +1,3 @@
-import type { ExternalProvider } from '@ethersproject/providers'
 import { providers } from 'ethers'
 import type {
   CoinbaseWalletProvider,
@@ -63,7 +62,7 @@ export class CoinbaseWalletConnector extends Connector<
         account,
         chain: { id, unsupported },
         provider: new providers.Web3Provider(
-          <ExternalProvider>(<unknown>provider),
+          <providers.ExternalProvider>(<unknown>provider),
         ),
       }
     } catch (error) {
@@ -131,7 +130,7 @@ export class CoinbaseWalletConnector extends Connector<
       this.getAccount(),
     ])
     return new providers.Web3Provider(
-      <ExternalProvider>(<unknown>provider),
+      <providers.ExternalProvider>(<unknown>provider),
     ).getSigner(account)
   }
 

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -1,4 +1,3 @@
-import type { ExternalProvider } from '@ethersproject/providers'
 import { providers } from 'ethers'
 import { getAddress, hexValue } from 'ethers/lib/utils'
 
@@ -129,9 +128,9 @@ export class InjectedConnector extends Connector<
       this.getProvider(),
       this.getAccount(),
     ])
-    return new providers.Web3Provider(<ExternalProvider>provider).getSigner(
-      account,
-    )
+    return new providers.Web3Provider(
+      <providers.ExternalProvider>provider,
+    ).getSigner(account)
   }
 
   async isAuthorized() {

--- a/packages/core/src/connectors/mock/provider.ts
+++ b/packages/core/src/connectors/mock/provider.ts
@@ -1,8 +1,6 @@
 import { default as EventEmitter } from 'eventemitter3'
-import { Signer } from 'ethers/lib/ethers'
+import { Signer, providers } from 'ethers'
 import { getAddress } from 'ethers/lib/utils'
-import type { Listener } from '@ethersproject/providers'
-import { providers } from 'ethers'
 
 import { UserRejectedRequestError } from '../../errors'
 
@@ -77,19 +75,19 @@ export class MockProvider extends providers.BaseProvider {
     return true
   }
 
-  on(event: Event, listener: Listener) {
+  on(event: Event, listener: providers.Listener) {
     this.events.on(event, listener)
     return this
   }
-  once(event: Event, listener: Listener) {
+  once(event: Event, listener: providers.Listener) {
     this.events.once(event, listener)
     return this
   }
-  removeListener(event: Event, listener: Listener) {
+  removeListener(event: Event, listener: providers.Listener) {
     this.events.removeListener(event, listener)
     return this
   }
-  off(event: Event, listener: Listener) {
+  off(event: Event, listener: providers.Listener) {
     this.events.off(event, listener)
     return this
   }

--- a/packages/core/src/connectors/walletConnect.ts
+++ b/packages/core/src/connectors/walletConnect.ts
@@ -1,4 +1,3 @@
-import type { ExternalProvider } from '@ethersproject/providers'
 import { providers } from 'ethers'
 import type WalletConnectProvider from '@walletconnect/ethereum-provider'
 import type { IWCEthRpcConnectionOptions } from '@walletconnect/types'
@@ -53,7 +52,9 @@ export class WalletConnectConnector extends Connector<
       return {
         account,
         chain: { id, unsupported },
-        provider: new providers.Web3Provider(<ExternalProvider>provider),
+        provider: new providers.Web3Provider(
+          <providers.ExternalProvider>provider,
+        ),
       }
     } catch (error) {
       if (/user closed modal/i.test((<ProviderRpcError>error).message))
@@ -102,9 +103,9 @@ export class WalletConnectConnector extends Connector<
       this.getProvider(),
       this.getAccount(),
     ])
-    return new providers.Web3Provider(<ExternalProvider>provider).getSigner(
-      account,
-    )
+    return new providers.Web3Provider(
+      <providers.ExternalProvider>provider,
+    ).getSigner(account)
   }
 
   async isAuthorized() {

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import type { BaseProvider, WebSocketProvider } from '@ethersproject/providers'
+import { providers } from 'ethers'
 import {
   WagmiClient,
   ClientConfig as WagmiClientConfig,
@@ -12,23 +12,24 @@ import { createWebStoragePersister } from 'react-query/createWebStoragePersister
 import { deserialize, serialize } from './utils'
 
 export type DecoratedWagmiClient<
-  TProvider extends BaseProvider = BaseProvider,
-  TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
+  TWebSocketProvider extends providers.WebSocketProvider = providers.WebSocketProvider,
 > = WagmiClient<TProvider, TWebSocketProvider> & { queryClient: QueryClient }
 export const Context = React.createContext<
-  DecoratedWagmiClient<BaseProvider, WebSocketProvider> | undefined
+  | DecoratedWagmiClient<providers.BaseProvider, providers.WebSocketProvider>
+  | undefined
 >(undefined)
 
 export type ClientConfig<
-  TProvider extends BaseProvider = BaseProvider,
-  TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
+  TWebSocketProvider extends providers.WebSocketProvider = providers.WebSocketProvider,
 > = WagmiClientConfig<TProvider, TWebSocketProvider> & {
   queryClient?: QueryClient
   persister?: Persister
 }
 export function createClient<
-  TProvider extends BaseProvider,
-  TWebSocketProvider extends WebSocketProvider,
+  TProvider extends providers.BaseProvider,
+  TWebSocketProvider extends providers.WebSocketProvider,
 >({
   queryClient = new QueryClient({
     defaultOptions: {
@@ -66,15 +67,15 @@ export function createClient<
 }
 
 export type ProviderProps<
-  TProvider extends BaseProvider = BaseProvider,
-  TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TProvider extends providers.BaseProvider = providers.BaseProvider,
+  TWebSocketProvider extends providers.WebSocketProvider = providers.WebSocketProvider,
 > = {
   /** React-decorated WagmiClient instance */
   client?: DecoratedWagmiClient<TProvider, TWebSocketProvider>
 }
 export function Provider<
-  TProvider extends BaseProvider,
-  TWebSocketProvider extends WebSocketProvider,
+  TProvider extends providers.BaseProvider,
+  TWebSocketProvider extends providers.WebSocketProvider,
 >({
   children,
   client = createClient<TProvider, TWebSocketProvider>(),
@@ -98,8 +99,8 @@ export function Provider<
 }
 
 export function useClient<
-  TProvider extends BaseProvider,
-  TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TProvider extends providers.BaseProvider,
+  TWebSocketProvider extends providers.WebSocketProvider = providers.WebSocketProvider,
 >() {
   const client = React.useContext(Context) as unknown as DecoratedWagmiClient<
     TProvider,

--- a/packages/react/src/hooks/providers/useProvider.ts
+++ b/packages/react/src/hooks/providers/useProvider.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import type { BaseProvider } from '@ethersproject/providers'
+import { providers } from 'ethers'
 import { GetProviderArgs, getProvider, watchProvider } from '@wagmi/core'
 
 import { useClient } from '../../context'
@@ -7,7 +7,7 @@ import { useForceUpdate } from '../utils'
 
 export type UseProviderArgs = Partial<GetProviderArgs>
 
-export function useProvider<TProvider extends BaseProvider>({
+export function useProvider<TProvider extends providers.BaseProvider>({
   chainId,
 }: UseProviderArgs = {}) {
   const forceUpdate = useForceUpdate()

--- a/packages/react/src/hooks/providers/useWebSocketProvider.ts
+++ b/packages/react/src/hooks/providers/useWebSocketProvider.ts
@@ -1,4 +1,4 @@
-import { WebSocketProvider } from '@ethersproject/providers'
+import { providers } from 'ethers'
 import {
   GetWebSocketProviderArgs,
   getWebSocketProvider,
@@ -12,7 +12,7 @@ import { useForceUpdate } from '../utils'
 export type UseWebSocketProviderArgs = Partial<GetWebSocketProviderArgs>
 
 export function useWebSocketProvider<
-  TWebSocketProvider extends WebSocketProvider,
+  TWebSocketProvider extends providers.WebSocketProvider,
 >({ chainId }: UseWebSocketProviderArgs = {}) {
   const forceUpdate = useForceUpdate()
   const client = useClient()

--- a/packages/react/test/utils.ts
+++ b/packages/react/test/utils.ts
@@ -1,6 +1,5 @@
-import { BaseProvider, WebSocketProvider } from '@ethersproject/providers'
 import { act } from '@testing-library/react'
-import { Contract } from 'ethers/lib/ethers'
+import { Contract, providers } from 'ethers'
 
 import { MockConnector } from '@wagmi/core/connectors/mock'
 
@@ -11,7 +10,7 @@ import { renderHook } from '.'
 type Config = Partial<ClientConfig>
 
 export function setupWagmiClient(config: Config = {}) {
-  return createClient<BaseProvider, WebSocketProvider>({
+  return createClient<providers.BaseProvider, providers.WebSocketProvider>({
     connectors: [
       new MockConnector({
         options: {


### PR DESCRIPTION
## Description

Since wagmi already has a peer dependency on `ethers`, this change helps ensure that consumers and other libraries they depend on don't inadvertently end up with multiple differing versions of `@ethersproject/providers`.

With this change, other libraries in the ecosystem can also rely on a single `ethers` peer dependency that's owned by the host app, ensuring that providers created in their library can be passed to wagmi without any errors.

As I was going through, I noticed that some of the ethers imports were from `ethers/lib/ethers`, but these still work when changed to just `ethers`. I fixed these up at the same time, but let me know if I've missed something there.

## Additional Information

- [x] I read the contributing docs (if this is your first contribution)

Your ENS/address: markdalgleish.eth
