### PR TITLE
Adding Opera Crypto Wallet connector

### DIFF
--- a/examples/_dev/src/pages/_app.tsx
+++ b/examples/_dev/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import NextHead from 'next/head'
 import { Provider, chain, createClient, defaultChains } from 'wagmi'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
+import { OperaConnector } from 'wagmi/connectors/opera'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
 import { providers } from 'ethers/lib/ethers'
@@ -25,6 +26,7 @@ const client = createClient({
       : chain.rpcUrls.default
     return [
       new MetaMaskConnector({ chains }),
+      new OperaConnector({ chains }),
       new CoinbaseWalletConnector({
         chains,
         options: {

--- a/packages/core/connectors/opera/package.json
+++ b/packages/core/connectors/opera/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/wagmi-core-connectors-opera.cjs.js",
+  "module": "dist/wagmi-core-connectors-opera.esm.js"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,10 @@
       "module": "./connectors/metaMask/dist/wagmi-core-connectors-metaMask.esm.js",
       "default": "./connectors/metaMask/dist/wagmi-core-connectors-metaMask.cjs.js"
     },
+    "./connectors/opera": {
+      "module": "./connectors/opera/dist/wagmi-core-connectors-opera.esm.js",
+      "default": "./connectors/opera/dist/wagmi-core-connectors-opera.cjs.js"
+    },
     "./connectors/mock": {
       "module": "./connectors/mock/dist/wagmi-core-connectors-mock.esm.js",
       "default": "./connectors/mock/dist/wagmi-core-connectors-mock.cjs.js"
@@ -41,6 +45,7 @@
       "index.ts",
       "connectors/coinbaseWallet.ts",
       "connectors/metaMask.ts",
+      "connectors/opera.ts",
       "connectors/walletConnect.ts",
       "connectors/mock/index.ts"
     ]

--- a/packages/core/src/connectors/opera.ts
+++ b/packages/core/src/connectors/opera.ts
@@ -1,0 +1,42 @@
+import { Chain } from '../types'
+import { InjectedConnector, InjectedConnectorOptions } from './injected'
+
+export type OperaConnectorOptions = Pick<
+  InjectedConnectorOptions,
+  'shimDisconnect'
+>
+
+export class OperaConnector extends InjectedConnector {
+  readonly id = 'opera'
+  readonly ready =
+    typeof window !== 'undefined' && !!this.#findProvider(window.ethereum)
+
+  #provider?: Window['ethereum']
+
+  constructor(config?: { chains?: Chain[]; options?: OperaConnectorOptions }) {
+    super({
+      ...config,
+      options: {
+        name: 'Opera',
+        shimDisconnect: true,
+        ...config?.options,
+      },
+    })
+  }
+
+  async getProvider() {
+    if (typeof window !== 'undefined')
+      this.#provider = this.#findProvider(window.ethereum)
+    return this.#provider
+  }
+
+  #getReady(ethereum?: Ethereum) {
+    const isOpera = !!ethereum?.isOpera
+    if (isOpera) return ethereum
+  }
+
+  #findProvider(ethereum?: Ethereum) {
+    if (ethereum?.providers) return ethereum.providers.find(this.#getReady)
+    return this.#getReady(ethereum)
+  }
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -62,6 +62,7 @@ declare global {
     isCoinbaseWallet?: true
     isFrame?: true
     isMetaMask?: true
+    isOpera?: true
     isTally?: true
     isTrust?: true
   }

--- a/packages/react/connectors/opera/package.json
+++ b/packages/react/connectors/opera/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/wagmi-connectors-opera.cjs.js",
+  "module": "dist/wagmi-connectors-opera.esm.js"
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,6 +28,10 @@
       "module": "./connectors/metaMask/dist/wagmi-connectors-metaMask.esm.js",
       "default": "./connectors/metaMask/dist/wagmi-connectors-metaMask.cjs.js"
     },
+    "./connectors/opera": {
+      "module": "./connectors/opera/dist/wagmi-connectors-opera.esm.js",
+      "default": "./connectors/opera/dist/wagmi-connectors-opera.cjs.js"
+    },
     "./connectors/walletConnect": {
       "module": "./connectors/walletConnect/dist/wagmi-connectors-walletConnect.esm.js",
       "default": "./connectors/walletConnect/dist/wagmi-connectors-walletConnect.cjs.js"
@@ -43,6 +47,7 @@
       "connectors/coinbaseWallet.ts",
       "connectors/injected.ts",
       "connectors/metaMask.ts",
+      "connectors/opera.ts",
       "connectors/walletConnect.ts"
     ]
   },

--- a/packages/react/src/connectors/opera.ts
+++ b/packages/react/src/connectors/opera.ts
@@ -1,0 +1,1 @@
+export { OperaConnector } from '@wagmi/core/connectors/opera'


### PR DESCRIPTION
## Description

Hi we would like to Opera Crypto Wallet connection to your library according to the official integration guide: https://help.opera.com/en/crypto/opera-wallet-integration-guide/
The code updates are based on wagmi's MetaMask/Injected wallet connectors and are officially supported by the Opera Crypto Browser team.

## Additional Information

- [x] I read the contributing docs (if this is your first contribution)

Your ENS/address:
