### PR TITLE
fix: autoconnect with stale account

### DIFF
--- a/.changeset/tidy-elephants-drive.md
+++ b/.changeset/tidy-elephants-drive.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+Fix case where connector disconnected while app was closed and stale data was returned when autoconnecting. For example, [MetaMask was locked](https://github.com/tmm/wagmi/issues/444) when page was closed.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -241,7 +241,12 @@ export class Client<
     }
 
     // If connecting didn't succeed, set to disconnected
-    if (!connected) this.setState((x) => ({ ...x, status: 'disconnected' }))
+    if (!connected)
+      this.setState((x) => ({
+        ...x,
+        data: undefined,
+        status: 'disconnected',
+      }))
 
     return this.data
   }


### PR DESCRIPTION
## Description

Fixes https://github.com/tmm/wagmi/issues/444 https://github.com/rainbow-me/rainbowkit/issues/347

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
