### PR TITLE
docs: useFeeData formatUnits default value

### DIFF
--- a/docs/pages/docs/hooks/useFeeData.en-US.mdx
+++ b/docs/pages/docs/hooks/useFeeData.en-US.mdx
@@ -77,7 +77,7 @@ function App() {
 
 ### formatUnits (optional)
 
-Formats fee data using ethers [units](https://docs.ethers.io/v5/api/utils/display-logic/#display-logic--units). Defaults to `ether`.
+Formats fee data using ethers [units](https://docs.ethers.io/v5/api/utils/display-logic/#display-logic--units). Defaults to `wei`.
 
 ```tsx {5}
 import { useFeeData } from 'wagmi'


### PR DESCRIPTION
## Description

I used the hook `useFeeData` and noticed an inaccuracy in the documentation. `formatUnits` option used the value "wei" by default. You can find it [here](https://github.com/tmm/wagmi/blob/main/packages/react/src/hooks/network-status/useFeeData.ts#L32)

I think this is a mistake. Because in order to use **ether** I had to explicitly specify `formatUnits: 'ether'` in my code. So, "ether" is not a default value.

