### PR TITLE
wrong connectAsync return data

### DIFF
--- a/docs/pages/examples/sign-in-with-ethereum.en-US.mdx
+++ b/docs/pages/examples/sign-in-with-ethereum.en-US.mdx
@@ -312,16 +312,14 @@ This guide splits SIWE into two steps: Connect wallet and sign SIWE message. If 
 ```ts
 try {
   const res = await connectAsync(connector) // `connectAsync` from `useConnect`
-  if (!res.data) throw res.error ?? new Error('Something went wrong')
-
   const nonceRes = await fetch('/api/nonce')
   const message = new SiweMessage({
     domain: window.location.host,
-    address: res.data.account,
+    address: res.account,
     statement: 'Sign in with Ethereum to the app.',
     uri: window.location.origin,
     version: '1',
-    chainId: res.data.chain?.id,
+    chainId: res.chain?.id,
     nonce: await nonceRes.text(),
   })
 


### PR DESCRIPTION
Contrary of `useConnect`, `connectAsync` doesn't have an error or data field.

https://wagmi.sh/docs/hooks/useConnect#return-value

## Description

_Concise description of proposed changes_

## Additional Information

- [ ] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
