### PR TITLE
Re-add Gnosis Chain support

### DIFF
--- a/.changeset/big-mugs-cough.md
+++ b/.changeset/big-mugs-cough.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+Add gnosis chain support

--- a/packages/core/src/constants/blockExplorers.ts
+++ b/packages/core/src/constants/blockExplorers.ts
@@ -12,6 +12,7 @@ type EtherscanChains = Extract<
   | 'kovan'
   | 'optimism'
   | 'optimismKovan'
+  | 'gnosis'
   | 'polygon'
   | 'polygonMumbai'
   | 'arbitrum'
@@ -45,6 +46,10 @@ export const etherscanBlockExplorers: Record<EtherscanChains, BlockExplorer> = {
   optimismKovan: {
     name: 'Etherscan',
     url: 'https://kovan-optimistic.etherscan.io',
+  },
+  gnosis: {
+    name: 'Blockscout',
+    url: 'https://blockscout.com',
   },
   polygon: {
     name: 'PolygonScan',

--- a/packages/core/src/constants/chains.ts
+++ b/packages/core/src/constants/chains.ts
@@ -12,6 +12,7 @@ export type ChainName =
   | 'mainnet'
   | 'optimism'
   | 'optimismKovan'
+  | 'gnosis'
   | 'polygon'
   | 'polygonMumbai'
   | 'rinkeby'
@@ -25,6 +26,7 @@ export const chainId = {
   kovan: 42,
   optimism: 10,
   optimismKovan: 69,
+  gnosis: 100,
   polygon: 137,
   polygonMumbai: 80_001,
   arbitrum: 42_161,
@@ -147,6 +149,17 @@ export const chain: Record<ChainName, Chain> = {
       default: etherscanBlockExplorers.optimismKovan,
     },
     testnet: true,
+  },
+  gnosis: {
+    id: chainId.gnosis,
+    name: 'Gnosis Chain',
+    network: 'gnosis-chain',
+    nativeCurrency: { name: 'xDai', symbol: 'xDAI', decimals: 18 },
+    rpcUrls: { default: 'https://rpc.gnosischain.com' },
+    blockExplorers: {
+      etherscan: etherscanBlockExplorers.gnosis,
+      default: etherscanBlockExplorers.gnosis,
+    },
   },
   polygon: {
     id: chainId.polygon,


### PR DESCRIPTION
## Description

This PR re-adds the missing gnosis chain configuration that was included in version [0.1.20](https://github.com/tmm/wagmi/pull/326) which got lost at some point as it doesn't exists anymore.
 
## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
