### PR TITLE
feat: make `defaultChains` type generic in `configureChains`

### DIFF
--- a/packages/core/src/chains/configureChains.ts
+++ b/packages/core/src/chains/configureChains.ts
@@ -22,15 +22,16 @@ export type ConfigureChainsConfig = { stallTimeout?: number } & (
 export function configureChains<
   TProvider extends Provider = Provider,
   TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
+  TChain extends Chain = Chain,
 >(
-  defaultChains: Chain[],
-  providers: ChainProvider<TProvider, TWebSocketProvider>[],
+  defaultChains: TChain[],
+  providers: ChainProvider<TProvider, TWebSocketProvider, TChain>[],
   { minQuorum = 1, targetQuorum = 1, stallTimeout }: ConfigureChainsConfig = {},
 ) {
   if (targetQuorum < minQuorum)
     throw new Error('quorum cannot be lower than minQuorum')
 
-  let chains: Chain[] = []
+  let chains: TChain[] = []
   const providers_: {
     [chainId: number]: (() => ProviderWithFallbackConfig<TProvider>)[]
   } = {}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -28,8 +28,9 @@ export type Chain = {
 export type ChainProvider<
   TProvider extends Provider = Provider,
   TWebSocketProvider extends WebSocketProvider = WebSocketProvider,
-> = (chain: Chain) => {
-  chain: Chain
+  TChain extends Chain = Chain,
+> = (chain: TChain) => {
+  chain: TChain
   provider: () => ProviderWithFallbackConfig<TProvider>
   webSocketProvider?: () => TWebSocketProvider
 } | null


### PR DESCRIPTION
## Description

Making the `defaultChains` type generic in `configureChains` as consumers may like to extend the `Chain` type (e.g. RainbowKit).
