### PR TITLE
Import configureChains from wagmi module

### DIFF
--- a/docs/pages/examples/connect-wallet.en-US.mdx
+++ b/docs/pages/examples/connect-wallet.en-US.mdx
@@ -13,7 +13,7 @@ The example below uses [`useConnect`](/docs/hooks/useConnect), [`useAccount`](/d
 First, we create a new wagmi client set up with the Injected (i.e. MetaMask), WalletConnect, and Coinbase Wallet connectors:
 
 ```tsx
-import { WagmiConfig, createClient, defaultChains } from 'wagmi'
+import { WagmiConfig, createClient, defaultChains, configureChains } from 'wagmi'
 
 import { alchemyProvider } from 'wagmi/providers/alchemy'
 import { publicProvider } from 'wagmi/providers/public'


### PR DESCRIPTION
## Description

configureChains is called but wasn't imported.

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
