### PR TITLE
fix: infer `chainId` config from `chains` on WalletConnectConnector

### DIFF
--- a/.changeset/eighty-baboons-provide.md
+++ b/.changeset/eighty-baboons-provide.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+infer `options.chainId` config from `chains` on WalletConnectConnector

--- a/packages/core/src/connectors/walletConnect.ts
+++ b/packages/core/src/connectors/walletConnect.ts
@@ -100,6 +100,7 @@ export class WalletConnectConnector extends Connector<
 
   async getProvider(create?: boolean) {
     if (!this.#provider || create) {
+      const chainId = this.options?.chainId || this.chains[0].id
       const rpc = !this.options?.infuraId
         ? this.chains.reduce(
             (rpc, chain) => ({
@@ -115,6 +116,7 @@ export class WalletConnectConnector extends Connector<
       ).default
       this.#provider = new WalletConnectProvider({
         ...this.options,
+        chainId,
         rpc: { ...rpc, ...this.options?.rpc },
       })
     }


### PR DESCRIPTION
## Description

Wagmi now infers the `options.chainId` attribute on `WalletConnectConnector` to the first chain in the `chains` array that is passed to the connector.

Fixes https://github.com/tmm/wagmi/issues/516