### PR TITLE
chore: update react-query

### DIFF
--- a/.changeset/empty-eyes-act.md
+++ b/.changeset/empty-eyes-act.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Update `react-query` to `4.0.0-beta.19`

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -91,7 +91,7 @@
     "@coinbase/wallet-sdk": "^3.1.0",
     "@wagmi/core": "^0.3.4",
     "@walletconnect/ethereum-provider": "^1.7.8",
-    "react-query": "^4.0.0-beta.15",
+    "react-query": "^4.0.0-beta.19",
     "use-sync-external-store": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Updating `react-query` to `4.0.0-beta.19` – this should fix issues we have been seeing around the `useSyncExternalStore` import.
