### PR TITLE
docs: fix type errors in custom chain example

### DIFF
--- a/docs/pages/docs/providers/configuring-chains.en-US.mdx
+++ b/docs/pages/docs/providers/configuring-chains.en-US.mdx
@@ -66,6 +66,7 @@ const infuraId = process.env.INFURA_ID
 const avalancheChain: Chain = {
   id: 43_114,
   name: 'Avalanche',
+  network: 'avalanche',
   nativeCurrency: {
     decimals: 18,
     name: 'Avalanche',
@@ -76,7 +77,7 @@ const avalancheChain: Chain = {
   },
   blockExplorers: {
     default: { name: 'SnowTrace', url: 'https://snowtrace.io' },
-    snowtrace: { name: 'SnowTrace', url: 'https://snowtrace.io' },
+    etherscan: { name: 'SnowTrace', url: 'https://snowtrace.io' },
   },
   testnet: false,
 }


### PR DESCRIPTION
## Description

The custom Avalanche chain example was missing the `network` property, and the `blockExplorers` object was missing a value for `etherscan`.

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: markdalgleish.eth
