### PR TITLE
feat: allow custom ens registry address

### DIFF
--- a/.changeset/hungry-ducks-compete.md
+++ b/.changeset/hungry-ducks-compete.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+add ensAddress to Chain type

--- a/packages/core/src/constants/chains.ts
+++ b/packages/core/src/constants/chains.ts
@@ -23,6 +23,7 @@ export const mainnet: Chain = {
   id: chainId.mainnet,
   name: 'Ethereum',
   network: 'homestead',
+  ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
   nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     alchemy: alchemyRpcUrls.mainnet,
@@ -39,6 +40,7 @@ export const ropsten: Chain = {
   id: chainId.ropsten,
   name: 'Ropsten',
   network: 'ropsten',
+  ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
   nativeCurrency: { name: 'Ropsten Ether', symbol: 'ropETH', decimals: 18 },
   rpcUrls: {
     alchemy: alchemyRpcUrls.ropsten,
@@ -56,6 +58,7 @@ export const rinkeby: Chain = {
   id: chainId.rinkeby,
   name: 'Rinkeby',
   network: 'rinkeby',
+  ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
   nativeCurrency: { name: 'Rinkeby Ether', symbol: 'rETH', decimals: 18 },
   rpcUrls: {
     alchemy: alchemyRpcUrls.rinkeby,
@@ -73,6 +76,7 @@ export const goerli: Chain = {
   id: chainId.goerli,
   name: 'Goerli',
   network: 'goerli',
+  ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
   nativeCurrency: { name: 'Goerli Ether', symbol: 'gETH', decimals: 18 },
   rpcUrls: {
     alchemy: alchemyRpcUrls.goerli,

--- a/packages/core/src/providers/jsonRpc.ts
+++ b/packages/core/src/providers/jsonRpc.ts
@@ -37,6 +37,7 @@ export function jsonRpcProvider({
         const provider = new RpcProvider(rpcConfig.http, {
           chainId: chain.id,
           name: chain.network,
+          ensAddress: chain.ensAddress,
         })
         if (pollingInterval) provider.pollingInterval = pollingInterval
         return Object.assign(provider, { priority, stallTimeout, weight })

--- a/packages/core/src/providers/jsonRpc.ts
+++ b/packages/core/src/providers/jsonRpc.ts
@@ -35,9 +35,9 @@ export function jsonRpcProvider({
           ? providers.StaticJsonRpcProvider
           : providers.JsonRpcProvider
         const provider = new RpcProvider(rpcConfig.http, {
+          ensAddress: chain.ensAddress,
           chainId: chain.id,
           name: chain.network,
-          ensAddress: chain.ensAddress,
         })
         if (pollingInterval) provider.pollingInterval = pollingInterval
         return Object.assign(provider, { priority, stallTimeout, weight })

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -30,6 +30,8 @@ export type Chain = {
   }
   /** Flag for test networks */
   testnet?: boolean
+  /** Custom ENS registry address */
+  ensAddress?: string
 }
 
 export type ChainProvider<

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -14,6 +14,8 @@ export type Chain = {
   name: string
   /** Internal network name */
   network: string
+  /** ENS registry address */
+  ensAddress?: string
   /** Currency used by chain */
   nativeCurrency?: AddEthereumChainParameter['nativeCurrency']
   /** Collection of RPC endpoints */
@@ -30,8 +32,6 @@ export type Chain = {
   }
   /** Flag for test networks */
   testnet?: boolean
-  /** Custom ENS registry address */
-  ensAddress?: string
 }
 
 export type ChainProvider<


### PR DESCRIPTION
## Description

This PR enables the usage of custom ENS registry addresses with rainbowkit/wagmi. Ethers also supports [this](https://docs.ethers.io/v5/api/providers/types/#providers-Network). 

We have a private chain for testing purposes where we [deployed ENS contracts](https://docs.ens.domains/deploying-ens-on-a-private-chain). In order for our dApp (uses rainbowkit and wagmi) to work with this target environment, we would need this feature, so that we can configure the chains like:
```js
const { chains, provider } = configureChains(
  [
    {
      name: 'private',
      rpcUrls: {
        default: 'https://private-rpc',
      },
      network: 'private',
      id: 123456,
      ensAddress: '0xCUSTOM_ENS_REGISTRY',
    },
  ],
  [
    jsonRpcProvider({
      rpc: (chain) => ({ http: chain.rpcUrls.default }),
    }),
  ],
)
```
There might also be some cases where people would like to override the default ENS registry address on existing default networks.

Thanks for providing theses awesome tools btw ❤️ 

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: dohaki.eth
