### PR TITLE
fix: fixed `parseContractResult` for more complex contract types

### DIFF
--- a/.changeset/hot-moles-happen.md
+++ b/.changeset/hot-moles-happen.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Fixed `parseContractResult` breaking `useContractRead` for more complex contract types

--- a/packages/react/src/utils/parseContractResult.test.ts
+++ b/packages/react/src/utils/parseContractResult.test.ts
@@ -1,8 +1,9 @@
 import { BigNumber } from 'ethers'
+import { Result } from 'ethers/lib/utils'
 
 import { parseContractResult } from './parseContractResult'
 
-const gmContractInterface = [
+const contractInterface = [
   {
     inputs: [
       {
@@ -27,42 +28,401 @@ const gmContractInterface = [
     stateMutability: 'view',
     type: 'function',
   },
-]
-
-const wagmigotchiContractConfig = [
   {
-    inputs: [{ internalType: 'address', name: '', type: 'address' }],
-    name: 'love',
-    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'withoutNames',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'simpleTuples',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'uint256',
+            name: 'timestamp',
+            type: 'uint256',
+          },
+          {
+            internalType: 'address',
+            name: 'sender',
+            type: 'address',
+          },
+        ],
+        internalType: 'struct Gms[]',
+        name: '',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'complexTuples',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'uint256',
+            name: 'timestamp',
+            type: 'uint256',
+          },
+          {
+            internalType: 'address',
+            name: 'sender',
+            type: 'address',
+          },
+          {
+            components: [
+              {
+                internalType: 'uint256',
+                name: 'timestamp',
+                type: 'uint256',
+              },
+              {
+                internalType: 'address',
+                name: 'sender',
+                type: 'address',
+              },
+            ],
+            internalType: 'struct Gms[]',
+            name: 'gms',
+            type: 'tuple[]',
+          },
+        ],
+        internalType: 'struct Gms[]',
+        name: '',
+        type: 'tuple[]',
+      },
+    ],
     stateMutability: 'view',
     type: 'function',
   },
 ]
 
 describe('parseContractResult', () => {
-  it('should parse the data to an ethers Result if there are no named keys', () => {
-    const data = [
-      BigNumber.from(1654322661),
-      '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-    ]
-    expect(
-      parseContractResult({
-        contractInterface: gmContractInterface,
+  describe('gms', () => {
+    it('should parse the data to an ethers Result if there are no named keys', () => {
+      const data = [
+        BigNumber.from(1654322661),
+        '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+      ]
+      const result = parseContractResult({
+        contractInterface,
         data,
-
         functionName: 'gms',
-      }),
-    ).toEqual(Object.assign(data, { timestamp: data[0], sender: data[1] }))
+      })
+      expect(result).toEqual(data)
+      expect(Object.keys(result).length !== data.length).toBeTruthy()
+      expect(result.timestamp).toEqual(data[0])
+      expect(result.sender).toEqual(data[1])
+    })
+
+    it('should return the data if in sync with ethers Result', () => {
+      const data = Object.assign(
+        [
+          BigNumber.from(1654322661),
+          '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+        ],
+        {
+          timestamp: BigNumber.from(1654322661),
+          sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+        },
+      )
+      const result = parseContractResult({
+        contractInterface,
+        data,
+        functionName: 'gms',
+      })
+      expect(Object.keys(result).length !== data.length).toBeTruthy()
+      expect(result).toEqual(data)
+      expect(result.timestamp).toEqual(data.timestamp)
+      expect(result.sender).toEqual(data.sender)
+    })
   })
 
-  it('should return the data if in sync with ethers Result', () => {
-    const data = [69]
-    expect(
-      parseContractResult({
-        contractInterface: wagmigotchiContractConfig,
+  describe('simpleTuples', () => {
+    it('should parse the data to an ethers Result if there are no named keys', () => {
+      const data: [BigNumber, string][] = [
+        [
+          BigNumber.from(1654322661),
+          '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+        ],
+        [
+          BigNumber.from(1654322662),
+          '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+        ],
+      ]
+      const result = parseContractResult({
+        contractInterface,
         data,
-        functionName: 'love',
-      }),
-    ).toEqual(data)
+        functionName: 'simpleTuples',
+      })
+
+      expect(Object.keys(result).length === data.length).toBeTruthy()
+      expect(result[0]).toEqual(data[0])
+      expect(Object.keys(result[0]).length !== data[0]?.length).toBeTruthy()
+      expect(result[0].timestamp).toEqual(data?.[0]?.[0])
+      expect(result[0].sender).toEqual(data?.[0]?.[1])
+      expect(result[1]).toEqual(data[1])
+      expect(Object.keys(result[1]).length !== data[1]?.length).toBeTruthy()
+      expect(result[1].timestamp).toEqual(data[1]?.[0])
+      expect(result[1].sender).toEqual(data[1]?.[1])
+    })
+
+    it('should return the data if in sync with ethers Result', () => {
+      const data: Result = [
+        Object.assign(
+          [
+            BigNumber.from(1654322661),
+            '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+          ],
+          {
+            timestamp: BigNumber.from(1654322661),
+            sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+          },
+        ),
+        Object.assign(
+          [
+            BigNumber.from(1654322662),
+            '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+          ],
+          {
+            timestamp: BigNumber.from(1654322662),
+            sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+          },
+        ),
+      ]
+      const result = parseContractResult({
+        contractInterface,
+        data,
+        functionName: 'complexTuples',
+      })
+
+      expect(Object.keys(result).length === data.length).toBeTruthy()
+      expect(result[0]).toEqual(data[0])
+      expect(Object.keys(result[0]).length !== data[0]?.length).toBeTruthy()
+      expect(result[0].timestamp).toEqual(data?.[0]?.timestamp)
+      expect(result[0].sender).toEqual(data?.[0]?.sender)
+      expect(result[1]).toEqual(data[1])
+      expect(Object.keys(result[1]).length !== data[1]?.length).toBeTruthy()
+      expect(result[1].timestamp).toEqual(data[1]?.timestamp)
+      expect(result[1].sender).toEqual(data[1]?.sender)
+    })
+  })
+
+  describe('complexTuples', () => {
+    it('should parse the data to an ethers Result if there are no named keys', () => {
+      const data: [BigNumber, string, [BigNumber, string][]][] = [
+        [
+          BigNumber.from(1654322661),
+          '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+          [
+            [
+              BigNumber.from(1654322661),
+              '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            ],
+            [
+              BigNumber.from(1654322661),
+              '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            ],
+          ],
+        ],
+        [
+          BigNumber.from(1654322662),
+          '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+          [
+            [
+              BigNumber.from(1654322661),
+              '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            ],
+            [
+              BigNumber.from(1654322661),
+              '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            ],
+          ],
+        ],
+      ]
+      const result = parseContractResult({
+        contractInterface,
+        data,
+        functionName: 'complexTuples',
+      })
+
+      expect(Object.keys(result).length === data.length).toBeTruthy()
+      expect(result[0]).toEqual(data[0])
+      expect(Object.keys(result[0]).length !== data[0]?.length).toBeTruthy()
+      expect(result[0].timestamp).toEqual(data?.[0]?.[0])
+      expect(result[0].sender).toEqual(data?.[0]?.[1])
+      expect(result[0].gms).toEqual(data?.[0]?.[2])
+      expect(result[0].gms[0]).toEqual(data?.[0]?.[2]?.[0])
+      expect(result[0].gms[0].timestamp).toEqual(data?.[0]?.[2]?.[0]?.[0])
+      expect(result[0].gms[0].sender).toEqual(data?.[0]?.[2]?.[0]?.[1])
+      expect(result[1]).toEqual(data[1])
+      expect(Object.keys(result[1]).length !== data[1]?.length).toBeTruthy()
+      expect(result[1].timestamp).toEqual(data[1]?.[0])
+      expect(result[1].sender).toEqual(data[1]?.[1])
+      expect(result[1].gms).toEqual(data?.[1]?.[2])
+      expect(result[1].gms[0]).toEqual(data?.[1]?.[2]?.[0])
+      expect(result[1].gms[0].timestamp).toEqual(data?.[1]?.[2]?.[0]?.[0])
+      expect(result[1].gms[0].sender).toEqual(data?.[1]?.[2]?.[0]?.[1])
+    })
+
+    it('should return the data if in sync with ethers Result', () => {
+      const data: Result = [
+        Object.assign(
+          [
+            BigNumber.from(1654322661),
+            '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            [
+              [
+                BigNumber.from(1654322661),
+                '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              ],
+              [
+                BigNumber.from(1654322661),
+                '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              ],
+            ],
+          ],
+          {
+            timestamp: BigNumber.from(1654322661),
+            sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            gms: [
+              Object.assign(
+                [
+                  BigNumber.from(1654322661),
+                  '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+                ],
+                {
+                  timestamp: BigNumber.from(1654322661),
+                  sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+                },
+              ),
+              Object.assign(
+                [
+                  BigNumber.from(1654322661),
+                  '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+                ],
+                {
+                  timestamp: BigNumber.from(1654322661),
+                  sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+                },
+              ),
+            ],
+          },
+        ),
+        Object.assign(
+          [
+            BigNumber.from(1654322662),
+            '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+            [
+              [
+                BigNumber.from(1654322661),
+                '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              ],
+              [
+                BigNumber.from(1654322661),
+                '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              ],
+            ],
+          ],
+          {
+            timestamp: BigNumber.from(1654322662),
+            sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+            gms: [
+              Object.assign(
+                [
+                  BigNumber.from(1654322661),
+                  '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+                ],
+                {
+                  timestamp: BigNumber.from(1654322661),
+                  sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+                },
+              ),
+              Object.assign(
+                [
+                  BigNumber.from(1654322661),
+                  '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+                ],
+                {
+                  timestamp: BigNumber.from(1654322661),
+                  sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+                },
+              ),
+            ],
+          },
+        ),
+      ]
+      const result = parseContractResult({
+        contractInterface,
+        data,
+        functionName: 'complexTuples',
+      })
+
+      expect(Object.keys(result).length === data.length).toBeTruthy()
+      expect(result[0]).toEqual(data[0])
+      expect(Object.keys(result[0]).length !== data[0]?.length).toBeTruthy()
+      expect(result[0].timestamp).toEqual(data?.[0]?.timestamp)
+      expect(result[0].sender).toEqual(data?.[0]?.sender)
+      expect(result[0].gms[0].timestamp).toEqual(data[0].gms[0].timestamp)
+      expect(result[0].gms[0].sender).toEqual(data[0].gms[0].sender)
+      expect(result[1]).toEqual(data[1])
+      expect(Object.keys(result[1]).length !== data[1]?.length).toBeTruthy()
+      expect(result[1].timestamp).toEqual(data[1]?.timestamp)
+      expect(result[1].sender).toEqual(data[1]?.sender)
+      expect(result[1].gms[0].timestamp).toEqual(data[1].gms[0].timestamp)
+      expect(result[1].gms[0].sender).toEqual(data[1].gms[0].sender)
+    })
+  })
+
+  describe('withoutNames', () => {
+    it('should parse the data to an ethers Result if there are no named keys', () => {
+      const data = [
+        BigNumber.from(1654322661),
+        '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+      ]
+      const result = parseContractResult({
+        contractInterface,
+        data,
+        functionName: 'withoutNames',
+      })
+      expect(result).toEqual(data)
+      expect(Object.keys(result).length === data.length).toBeTruthy()
+    })
   })
 })

--- a/packages/react/src/utils/parseContractResult.test.ts
+++ b/packages/react/src/utils/parseContractResult.test.ts
@@ -42,7 +42,7 @@ describe('parseContractResult', () => {
         data,
         functionName: 'gms',
       })
-      expect(result).toEqual(data)
+      expect(JSON.stringify(result)).toEqual(JSON.stringify(data))
       expect(Object.keys(result).length !== data.length).toBeTruthy()
       expect(result.timestamp).toEqual(data[0])
       expect(result.sender).toEqual(data[1])
@@ -148,9 +148,6 @@ describe('parseContractResult', () => {
         functionName: 'addresses',
       })
       expect(result).toEqual(data)
-      expect(Object.keys(result).length !== data.length).toBeTruthy()
-      expect(result.addresses[0]).toEqual(data[0])
-      expect(result.addresses[1]).toEqual(data[1])
     })
   })
 
@@ -232,7 +229,7 @@ describe('parseContractResult', () => {
         ],
         [
           BigNumber.from(1654322662),
-          '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+          '0xa5Cc3C03994DB5B0d9a5EEdD10CaBab0813678ad',
         ],
       ]
       const result = parseContractResult({
@@ -242,11 +239,11 @@ describe('parseContractResult', () => {
       })
 
       expect(Object.keys(result).length === data.length).toBeTruthy()
-      expect(result[0]).toEqual(data[0])
+      expect(JSON.stringify(result[0])).toEqual(JSON.stringify(data[0]))
       expect(Object.keys(result[0]).length !== data[0]?.length).toBeTruthy()
       expect(result[0].timestamp).toEqual(data?.[0]?.[0])
       expect(result[0].sender).toEqual(data?.[0]?.[1])
-      expect(result[1]).toEqual(data[1])
+      expect(JSON.stringify(result[1])).toEqual(JSON.stringify(data[1]))
       expect(Object.keys(result[1]).length !== data[1]?.length).toBeTruthy()
       expect(result[1].timestamp).toEqual(data[1]?.[0])
       expect(result[1].sender).toEqual(data[1]?.[1])
@@ -267,11 +264,11 @@ describe('parseContractResult', () => {
         Object.assign(
           [
             BigNumber.from(1654322662),
-            '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+            '0xa5Cc3C03994DB5B0d9a5EEdD10CaBab0813678ad',
           ],
           {
             timestamp: BigNumber.from(1654322662),
-            sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+            sender: '0xa5Cc3C03994DB5B0d9a5EEdD10CaBab0813678ad',
           },
         ),
       ]
@@ -282,7 +279,7 @@ describe('parseContractResult', () => {
       })
 
       expect(Object.keys(result).length === data.length).toBeTruthy()
-      expect(result[0]).toEqual(data[0])
+      expect(JSON.stringify(result[0])).toEqual(JSON.stringify(data[0]))
       expect(Object.keys(result[0]).length !== data[0]?.length).toBeTruthy()
       expect(result[0].timestamp).toEqual(data?.[0]?.timestamp)
       expect(result[0].sender).toEqual(data?.[0]?.sender)
@@ -351,7 +348,7 @@ describe('parseContractResult', () => {
           BigNumber.from(1654322661),
           [
             '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-            '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+            '0xa5Cc3C03994DB5B0d9a5EEdD10CaBab0813678ad',
           ],
           [
             [
@@ -368,7 +365,7 @@ describe('parseContractResult', () => {
           BigNumber.from(1654322662),
           [
             '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-            '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+            '0xa5Cc3C03994DB5B0d9a5EEdD10CaBab0813678ad',
           ],
           [
             [
@@ -389,20 +386,28 @@ describe('parseContractResult', () => {
       })
 
       expect(Object.keys(result).length === data.length).toBeTruthy()
-      expect(result[0]).toEqual(data[0])
+      expect(JSON.stringify(result[0])).toEqual(JSON.stringify(data[0]))
       expect(Object.keys(result[0]).length !== data[0]?.length).toBeTruthy()
       expect(result[0].timestamp).toEqual(data?.[0]?.[0])
       expect(result[0].senders).toEqual(data?.[0]?.[1])
-      expect(result[0].gms).toEqual(data?.[0]?.[2])
-      expect(result[0].gms[0]).toEqual(data?.[0]?.[2]?.[0])
+      expect(JSON.stringify(result[0].gms)).toEqual(
+        JSON.stringify(data?.[0]?.[2]),
+      )
+      expect(JSON.stringify(result[0].gms[0])).toEqual(
+        JSON.stringify(data?.[0]?.[2]?.[0]),
+      )
       expect(result[0].gms[0].timestamp).toEqual(data?.[0]?.[2]?.[0]?.[0])
       expect(result[0].gms[0].sender).toEqual(data?.[0]?.[2]?.[0]?.[1])
-      expect(result[1]).toEqual(data[1])
+      expect(JSON.stringify(result[1])).toEqual(JSON.stringify(data[1]))
       expect(Object.keys(result[1]).length !== data[1]?.length).toBeTruthy()
       expect(result[1].timestamp).toEqual(data[1]?.[0])
       expect(result[1].senders).toEqual(data[1]?.[1])
-      expect(result[1].gms).toEqual(data?.[1]?.[2])
-      expect(result[1].gms[0]).toEqual(data?.[1]?.[2]?.[0])
+      expect(JSON.stringify(result[1].gms)).toEqual(
+        JSON.stringify(data?.[1]?.[2]),
+      )
+      expect(JSON.stringify(result[1].gms[0])).toEqual(
+        JSON.stringify(data?.[1]?.[2]?.[0]),
+      )
       expect(result[1].gms[0].timestamp).toEqual(data?.[1]?.[2]?.[0]?.[0])
       expect(result[1].gms[0].sender).toEqual(data?.[1]?.[2]?.[0]?.[1])
     })
@@ -412,7 +417,10 @@ describe('parseContractResult', () => {
         Object.assign(
           [
             BigNumber.from(1654322661),
-            '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            [
+              '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              '0xa5Cc3C03994DB5B0d9a5EEdD10CaBab0813678ad',
+            ],
             [
               [
                 BigNumber.from(1654322661),
@@ -426,7 +434,10 @@ describe('parseContractResult', () => {
           ],
           {
             timestamp: BigNumber.from(1654322661),
-            sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            senders: [
+              '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              '0xa5Cc3C03994DB5B0d9a5EEdD10CaBab0813678ad',
+            ],
             gms: [
               Object.assign(
                 [
@@ -454,7 +465,10 @@ describe('parseContractResult', () => {
         Object.assign(
           [
             BigNumber.from(1654322662),
-            '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+            [
+              '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              '0xa5Cc3C03994DB5B0d9a5EEdD10CaBab0813678ad',
+            ],
             [
               [
                 BigNumber.from(1654322661),
@@ -468,7 +482,10 @@ describe('parseContractResult', () => {
           ],
           {
             timestamp: BigNumber.from(1654322662),
-            sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+            senders: [
+              '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              '0xa5Cc3C03994DB5B0d9a5EEdD10CaBab0813678ad',
+            ],
             gms: [
               Object.assign(
                 [
@@ -501,13 +518,13 @@ describe('parseContractResult', () => {
       })
 
       expect(Object.keys(result).length === data.length).toBeTruthy()
-      expect(result[0]).toEqual(data[0])
+      expect(JSON.stringify(result[0])).toEqual(JSON.stringify(data[0]))
       expect(Object.keys(result[0]).length !== data[0]?.length).toBeTruthy()
       expect(result[0].timestamp).toEqual(data?.[0]?.timestamp)
       expect(result[0].sender).toEqual(data?.[0]?.sender)
       expect(result[0].gms[0].timestamp).toEqual(data[0].gms[0].timestamp)
       expect(result[0].gms[0].sender).toEqual(data[0].gms[0].sender)
-      expect(result[1]).toEqual(data[1])
+      expect(JSON.stringify(result[1])).toEqual(JSON.stringify(data[1]))
       expect(Object.keys(result[1]).length !== data[1]?.length).toBeTruthy()
       expect(result[1].timestamp).toEqual(data[1]?.timestamp)
       expect(result[1].sender).toEqual(data[1]?.sender)

--- a/packages/react/src/utils/parseContractResult.test.ts
+++ b/packages/react/src/utils/parseContractResult.test.ts
@@ -3,138 +3,35 @@ import { Result } from 'ethers/lib/utils'
 
 import { parseContractResult } from './parseContractResult'
 
-const contractInterface = [
-  {
-    inputs: [
-      {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256',
-      },
-    ],
-    name: 'gms',
-    outputs: [
-      {
-        internalType: 'uint256',
-        name: 'timestamp',
-        type: 'uint256',
-      },
-      {
-        internalType: 'address',
-        name: 'sender',
-        type: 'address',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256',
-      },
-    ],
-    name: 'withoutNames',
-    outputs: [
-      {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256',
-      },
-      {
-        internalType: 'address',
-        name: '',
-        type: 'address',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256',
-      },
-    ],
-    name: 'simpleTuples',
-    outputs: [
-      {
-        components: [
-          {
-            internalType: 'uint256',
-            name: 'timestamp',
-            type: 'uint256',
-          },
-          {
-            internalType: 'address',
-            name: 'sender',
-            type: 'address',
-          },
-        ],
-        internalType: 'struct Gms[]',
-        name: '',
-        type: 'tuple[]',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256',
-      },
-    ],
-    name: 'complexTuples',
-    outputs: [
-      {
-        components: [
-          {
-            internalType: 'uint256',
-            name: 'timestamp',
-            type: 'uint256',
-          },
-          {
-            internalType: 'address',
-            name: 'sender',
-            type: 'address',
-          },
-          {
-            components: [
-              {
-                internalType: 'uint256',
-                name: 'timestamp',
-                type: 'uint256',
-              },
-              {
-                internalType: 'address',
-                name: 'sender',
-                type: 'address',
-              },
-            ],
-            internalType: 'struct Gms[]',
-            name: 'gms',
-            type: 'tuple[]',
-          },
-        ],
-        internalType: 'struct Gms[]',
-        name: '',
-        type: 'tuple[]',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-]
-
 describe('parseContractResult', () => {
-  describe('gms', () => {
+  describe('struct', () => {
+    const contractInterface = [
+      {
+        inputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        name: 'gms',
+        outputs: [
+          {
+            internalType: 'uint256',
+            name: 'timestamp',
+            type: 'uint256',
+          },
+          {
+            internalType: 'address',
+            name: 'sender',
+            type: 'address',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ]
+
     it('should parse the data to an ethers Result if there are no named keys', () => {
       const data = [
         BigNumber.from(1654322661),
@@ -174,7 +71,159 @@ describe('parseContractResult', () => {
     })
   })
 
-  describe('simpleTuples', () => {
+  describe('struct with no named attributes', () => {
+    const contractInterface = [
+      {
+        inputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        name: 'withoutNames',
+        outputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+          {
+            internalType: 'address',
+            name: '',
+            type: 'address',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ]
+
+    it('should parse the data to an ethers Result', () => {
+      const data = [
+        BigNumber.from(1654322661),
+        '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+      ]
+      const result = parseContractResult({
+        contractInterface,
+        data,
+        functionName: 'withoutNames',
+      })
+      expect(result).toEqual(data)
+      expect(Object.keys(result).length === data.length).toBeTruthy()
+    })
+  })
+
+  describe('array', () => {
+    const contractInterface = [
+      {
+        inputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        name: 'addresses',
+        outputs: [
+          {
+            internalType: 'address[]',
+            name: 'addresses',
+            type: 'address[]',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ]
+
+    it('should parse the data to an ethers Result', () => {
+      const data = [
+        '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+        '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+      ]
+      const result = parseContractResult({
+        contractInterface,
+        data,
+        functionName: 'addresses',
+      })
+      expect(result).toEqual(data)
+      expect(Object.keys(result).length !== data.length).toBeTruthy()
+      expect(result.addresses[0]).toEqual(data[0])
+      expect(result.addresses[1]).toEqual(data[1])
+    })
+  })
+
+  describe('array with no named attributes', () => {
+    const contractInterface = [
+      {
+        inputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        name: 'indexes',
+        outputs: [
+          {
+            internalType: 'uint256[]',
+            name: '',
+            type: 'uint256[]',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ]
+
+    it('should parse the data to an ethers Result', () => {
+      const data = [BigNumber.from(1), BigNumber.from(2), BigNumber.from(3)]
+      const result = parseContractResult({
+        contractInterface,
+        data,
+        functionName: 'indexes',
+      })
+      expect(result).toEqual(data)
+      expect(Object.keys(result).length === data.length).toBeTruthy()
+    })
+  })
+
+  describe('array of simple tuples', () => {
+    const contractInterface = [
+      {
+        inputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        name: 'simpleTuples',
+        outputs: [
+          {
+            components: [
+              {
+                internalType: 'uint256',
+                name: 'timestamp',
+                type: 'uint256',
+              },
+              {
+                internalType: 'address',
+                name: 'sender',
+                type: 'address',
+              },
+            ],
+            internalType: 'struct Gms[]',
+            name: '',
+            type: 'tuple[]',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ]
+
     it('should parse the data to an ethers Result if there are no named keys', () => {
       const data: [BigNumber, string][] = [
         [
@@ -229,7 +278,7 @@ describe('parseContractResult', () => {
       const result = parseContractResult({
         contractInterface,
         data,
-        functionName: 'complexTuples',
+        functionName: 'simpleTuples',
       })
 
       expect(Object.keys(result).length === data.length).toBeTruthy()
@@ -244,12 +293,66 @@ describe('parseContractResult', () => {
     })
   })
 
-  describe('complexTuples', () => {
+  describe('array of complex tuples', () => {
+    const contractInterface = [
+      {
+        inputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        name: 'complexTuples',
+        outputs: [
+          {
+            components: [
+              {
+                internalType: 'uint256',
+                name: 'timestamp',
+                type: 'uint256',
+              },
+              {
+                internalType: 'address[]',
+                name: 'senders',
+                type: 'address[]',
+              },
+              {
+                components: [
+                  {
+                    internalType: 'uint256',
+                    name: 'timestamp',
+                    type: 'uint256',
+                  },
+                  {
+                    internalType: 'address',
+                    name: 'sender',
+                    type: 'address',
+                  },
+                ],
+                internalType: 'struct Gms[]',
+                name: 'gms',
+                type: 'tuple[]',
+              },
+            ],
+            internalType: 'struct Gms[]',
+            name: '',
+            type: 'tuple[]',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ]
+
     it('should parse the data to an ethers Result if there are no named keys', () => {
-      const data: [BigNumber, string, [BigNumber, string][]][] = [
+      const data: [BigNumber, string[], [BigNumber, string][]][] = [
         [
           BigNumber.from(1654322661),
-          '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+          [
+            '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+          ],
           [
             [
               BigNumber.from(1654322661),
@@ -263,7 +366,10 @@ describe('parseContractResult', () => {
         ],
         [
           BigNumber.from(1654322662),
-          '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+          [
+            '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AD',
+          ],
           [
             [
               BigNumber.from(1654322661),
@@ -286,7 +392,7 @@ describe('parseContractResult', () => {
       expect(result[0]).toEqual(data[0])
       expect(Object.keys(result[0]).length !== data[0]?.length).toBeTruthy()
       expect(result[0].timestamp).toEqual(data?.[0]?.[0])
-      expect(result[0].sender).toEqual(data?.[0]?.[1])
+      expect(result[0].senders).toEqual(data?.[0]?.[1])
       expect(result[0].gms).toEqual(data?.[0]?.[2])
       expect(result[0].gms[0]).toEqual(data?.[0]?.[2]?.[0])
       expect(result[0].gms[0].timestamp).toEqual(data?.[0]?.[2]?.[0]?.[0])
@@ -294,7 +400,7 @@ describe('parseContractResult', () => {
       expect(result[1]).toEqual(data[1])
       expect(Object.keys(result[1]).length !== data[1]?.length).toBeTruthy()
       expect(result[1].timestamp).toEqual(data[1]?.[0])
-      expect(result[1].sender).toEqual(data[1]?.[1])
+      expect(result[1].senders).toEqual(data[1]?.[1])
       expect(result[1].gms).toEqual(data?.[1]?.[2])
       expect(result[1].gms[0]).toEqual(data?.[1]?.[2]?.[0])
       expect(result[1].gms[0].timestamp).toEqual(data?.[1]?.[2]?.[0]?.[0])
@@ -407,22 +513,6 @@ describe('parseContractResult', () => {
       expect(result[1].sender).toEqual(data[1]?.sender)
       expect(result[1].gms[0].timestamp).toEqual(data[1].gms[0].timestamp)
       expect(result[1].gms[0].sender).toEqual(data[1].gms[0].sender)
-    })
-  })
-
-  describe('withoutNames', () => {
-    it('should parse the data to an ethers Result if there are no named keys', () => {
-      const data = [
-        BigNumber.from(1654322661),
-        '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-      ]
-      const result = parseContractResult({
-        contractInterface,
-        data,
-        functionName: 'withoutNames',
-      })
-      expect(result).toEqual(data)
-      expect(Object.keys(result).length === data.length).toBeTruthy()
     })
   })
 })

--- a/packages/react/src/utils/parseContractResult.ts
+++ b/packages/react/src/utils/parseContractResult.ts
@@ -1,5 +1,5 @@
 import { Contract, ContractInterface } from 'ethers/lib/ethers'
-import { FunctionFragment, Result } from 'ethers/lib/utils'
+import { Result } from 'ethers/lib/utils'
 
 function isPlainArray(value: unknown) {
   return Array.isArray(value) && Object.keys(value).length === value.length
@@ -15,77 +15,18 @@ export function parseContractResult({
   functionName: string
 }) {
   if (data && isPlainArray(data)) {
-    const { fragments } = Contract.getInterface(contractInterface)
-    const functionFragment = FunctionFragment.from(
-      fragments.find((fragment) => fragment.name === functionName) || {},
+    const iface = Contract.getInterface(contractInterface)
+    const fragment = iface.getFunction(functionName)
+
+    const isArray = fragment?.outputs?.[0]?.baseType === 'array'
+
+    const data_ = isArray ? [data] : data
+    const encodedResult = iface.encodeFunctionResult(functionName, data_)
+    const decodedResult = iface.decodeFunctionResult(
+      functionName,
+      encodedResult,
     )
-    return getFunctionData({
-      data,
-      outputs: functionFragment.outputs,
-    })
+    return isArray ? decodedResult[0] : decodedResult
   }
   return data
-}
-
-function getFunctionData({
-  data,
-  outputs,
-  isTuple = outputs?.[0]?.type === 'tuple[]',
-}: {
-  data: Result
-  outputs: FunctionFragment['outputs']
-  isTuple?: boolean
-}): Result {
-  if (outputs?.[0]?.type === 'tuple[]') {
-    // If all the tuple items are already in sync with the ethers Result,
-    // return the data.
-    if (data.some((data) => !isPlainArray(data))) {
-      return data
-    }
-
-    // Otherwise, traverse and parse the data to an ethers Result
-    return getFunctionData({
-      data,
-      outputs: outputs?.[0].components,
-      isTuple: true,
-    })
-  }
-
-  const data_ =
-    isPlainArray(data) && !data.some((data) => !Array.isArray(data))
-      ? data
-      : [data]
-  const result = data_.map((data) => {
-    let dataObject
-    if (
-      outputs?.[0]?.baseType === 'array' &&
-      outputs?.[0]?.type !== 'tuple[]' &&
-      outputs?.[0]?.name
-    ) {
-      dataObject = { [outputs?.[0]?.name]: [...data] }
-    } else {
-      dataObject = outputs?.reduce(
-        (dataObject, output, i) =>
-          output.name
-            ? {
-                ...dataObject,
-                [output.name]:
-                  output.type === 'tuple[]'
-                    ? getFunctionData({
-                        data: data[i],
-                        outputs: output.components,
-                        isTuple: true,
-                      })
-                    : data[i],
-              }
-            : dataObject,
-        {},
-      )
-    }
-
-    return Object.assign(data, dataObject)
-  })
-
-  if (!isTuple) return result[0]
-  return result
 }

--- a/packages/react/src/utils/parseContractResult.ts
+++ b/packages/react/src/utils/parseContractResult.ts
@@ -56,23 +56,33 @@ function getFunctionData({
       ? data
       : [data]
   const result = data_.map((data) => {
-    const dataObject = outputs?.reduce(
-      (dataObject, output, i) =>
-        output.name
-          ? {
-              ...dataObject,
-              [output.name]:
-                output.type === 'tuple[]'
-                  ? getFunctionData({
-                      data: data[i],
-                      outputs: output.components,
-                      isTuple: true,
-                    })
-                  : data[i],
-            }
-          : dataObject,
-      {},
-    )
+    let dataObject
+    if (
+      outputs?.[0]?.baseType === 'array' &&
+      outputs?.[0]?.type !== 'tuple[]' &&
+      outputs?.[0]?.name
+    ) {
+      dataObject = { [outputs?.[0]?.name]: [...data] }
+    } else {
+      dataObject = outputs?.reduce(
+        (dataObject, output, i) =>
+          output.name
+            ? {
+                ...dataObject,
+                [output.name]:
+                  output.type === 'tuple[]'
+                    ? getFunctionData({
+                        data: data[i],
+                        outputs: output.components,
+                        isTuple: true,
+                      })
+                    : data[i],
+              }
+            : dataObject,
+        {},
+      )
+    }
+
     return Object.assign(data, dataObject)
   })
 

--- a/packages/react/src/utils/parseContractResult.ts
+++ b/packages/react/src/utils/parseContractResult.ts
@@ -1,6 +1,10 @@
 import { Contract, ContractInterface } from 'ethers/lib/ethers'
 import { FunctionFragment, Result } from 'ethers/lib/utils'
 
+function isPlainArray(value: unknown) {
+  return Array.isArray(value) && Object.keys(value).length === value.length
+}
+
 export function parseContractResult({
   contractInterface,
   data,
@@ -10,19 +14,68 @@ export function parseContractResult({
   data: Result
   functionName: string
 }) {
-  if (data && Array.isArray(data) && Object.keys(data).length === data.length) {
+  if (data && isPlainArray(data)) {
     const { fragments } = Contract.getInterface(contractInterface)
     const functionFragment = FunctionFragment.from(
       fragments.find((fragment) => fragment.name === functionName) || {},
     )
-    const dataObject = functionFragment.outputs?.reduce(
-      (dataObject, output, i) => ({
-        ...dataObject,
-        [output.name]: data[i],
-      }),
+    return getFunctionData({
+      data,
+      outputs: functionFragment.outputs,
+    })
+  }
+  return data
+}
+
+function getFunctionData({
+  data,
+  outputs,
+  isTuple = outputs?.[0]?.type === 'tuple[]',
+}: {
+  data: Result
+  outputs: FunctionFragment['outputs']
+  isTuple?: boolean
+}): Result {
+  if (outputs?.[0]?.type === 'tuple[]') {
+    // If all the tuple items are already in sync with the ethers Result,
+    // return the data.
+    if (data.some((data) => !isPlainArray(data))) {
+      return data
+    }
+
+    // Otherwise, traverse and parse the data to an ethers Result
+    return getFunctionData({
+      data,
+      outputs: outputs?.[0].components,
+      isTuple: true,
+    })
+  }
+
+  const data_ =
+    isPlainArray(data) && !data.some((data) => !Array.isArray(data))
+      ? data
+      : [data]
+  const result = data_.map((data) => {
+    const dataObject = outputs?.reduce(
+      (dataObject, output, i) =>
+        output.name
+          ? {
+              ...dataObject,
+              [output.name]:
+                output.type === 'tuple[]'
+                  ? getFunctionData({
+                      data: data[i],
+                      outputs: output.components,
+                      isTuple: true,
+                    })
+                  : data[i],
+            }
+          : dataObject,
       {},
     )
     return Object.assign(data, dataObject)
-  }
-  return data
+  })
+
+  if (!isTuple) return result[0]
+  return result
 }


### PR DESCRIPTION
## Description

It turns out that if a contract method returned a tuple of structs, this would cause `parseContractResult` to run into an issue where it would assign `null` to the returned array. In some cases, this also [produced an error](https://github.com/tmm/wagmi/pull/552#issuecomment-1149537541).

I have fixed those cases in this PR, and have also tightened up the test cases for `parseContractResult` abit to also cover complex return types.

