### PR TITLE
fix #591 add explicit return type for mutationKey in useSignTypedData

### DIFF
--- a/packages/react/src/hooks/accounts/useSignTypedData.ts
+++ b/packages/react/src/hooks/accounts/useSignTypedData.ts
@@ -16,7 +16,9 @@ export type UseSignTypedDataConfig = MutationConfig<
   SignTypedDataArgs
 >
 
-export const mutationKey = (args: UseSignTypedDataArgs) => [
+export const mutationKey = (
+  args: UseSignTypedDataArgs,
+): ({ entity: string } & UseSignTypedDataArgs)[] => [
   { entity: 'signTypedData', ...args },
 ]
 


### PR DESCRIPTION
## Description

This fixes the reference to source files in the production bundle (#591). I don't know the reason for the problem, but this seems to fix it. I also tried to update babel, babel presets, and typescript compiler, but it didn't help

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0xbc2BB26a6d821e69A38016f3858561a1D80d4182
