### PR TITLE
feat: add package.json types field

### DIFF
--- a/.changeset/poor-carpets-repeat.md
+++ b/.changeset/poor-carpets-repeat.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': minor
+'wagmi': minor
+---
+
+**Breaking**: `TypedDataDomain` and `TypedDataField` types were removed and incorporated into `SignTypedDataArgs`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,9 +6,20 @@
   "repository": "tmm/wagmi",
   "author": "awkweb.eth",
   "ethereum": "awkweb.eth",
+  "funding": [
+    {
+      "type": "gitcoin",
+      "url": "https://gitcoin.co/grants/4493/wagmi-react-hooks-library-for-ethereum"
+    },
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/tmm"
+    }
+  ],
   "sideEffects": false,
   "main": "dist/wagmi-core.cjs.js",
   "module": "dist/wagmi-core.esm.js",
+  "types": "dist/wagmi-core.cjs.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/packages/core/src/actions/accounts/signTypedData.ts
+++ b/packages/core/src/actions/accounts/signTypedData.ts
@@ -7,24 +7,17 @@ import {
 } from '../../errors'
 import { fetchSigner } from './fetchSigner'
 
-export interface TypedDataDomain {
-  name?: string
-  version?: string
-  chainId?: BigNumberish
-  verifyingContract?: string
-  salt?: BytesLike
-}
-
-export interface TypedDataField {
-  name: string
-  type: string
-}
-
 export type SignTypedDataArgs = {
   /** Domain or domain signature for origin or contract */
-  domain: TypedDataDomain
+  domain: {
+    name?: string
+    version?: string
+    chainId?: BigNumberish
+    verifyingContract?: string
+    salt?: BytesLike
+  }
   /** Named list of all type definitions */
-  types: Record<string, Array<TypedDataField>>
+  types: Record<string, Array<{ name: string; type: string }>>
   /** Data to sign */
   value: Record<string, any>
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,6 +20,7 @@
   "sideEffects": false,
   "main": "dist/wagmi.cjs.js",
   "module": "dist/wagmi.esm.js",
+  "types": "dist/wagmi.cjs.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/packages/react/src/hooks/accounts/useConnect.ts
+++ b/packages/react/src/hooks/accounts/useConnect.ts
@@ -24,9 +24,8 @@ export type UseConnectConfig = {
   onSettled?: MutationOptions['onSettled']
 }
 
-export const mutationKey = (args: UseConnectArgs) => [
-  { entity: 'connect', ...args },
-]
+export const mutationKey = (args: UseConnectArgs) =>
+  [{ entity: 'connect', ...args }] as const
 
 const mutationFn = (args: UseConnectArgs) => {
   const { connector, chainId } = args

--- a/packages/react/src/hooks/accounts/useDisconnect.ts
+++ b/packages/react/src/hooks/accounts/useDisconnect.ts
@@ -17,7 +17,7 @@ export type UseDisconnectConfig = {
   onSuccess?: (context: unknown) => void | Promise<unknown>
 }
 
-export const mutationKey = [{ entity: 'disconnect' }]
+export const mutationKey = [{ entity: 'disconnect' }] as const
 
 const mutationFn = () => disconnect()
 

--- a/packages/react/src/hooks/accounts/useNetwork.ts
+++ b/packages/react/src/hooks/accounts/useNetwork.ts
@@ -20,9 +20,8 @@ export type UseNetworkConfig = MutationConfig<
   SwitchNetworkArgs
 >
 
-export const mutationKey = (args: UseNetworkArgs) => [
-  { entity: 'switchNetwork', ...args },
-]
+export const mutationKey = (args: UseNetworkArgs) =>
+  [{ entity: 'switchNetwork', ...args }] as const
 
 const mutationFn = (args: UseNetworkArgs) => {
   const { chainId } = args

--- a/packages/react/src/hooks/accounts/useSignMessage.ts
+++ b/packages/react/src/hooks/accounts/useSignMessage.ts
@@ -12,9 +12,8 @@ export type UseSignMessageConfig = MutationConfig<
   SignMessageArgs
 >
 
-export const mutationKey = (args: UseSignMessageArgs) => [
-  { entity: 'signMessage', ...args },
-]
+export const mutationKey = (args: UseSignMessageArgs) =>
+  [{ entity: 'signMessage', ...args }] as const
 
 const mutationFn = (args: UseSignMessageArgs) => {
   const { message } = args

--- a/packages/react/src/hooks/accounts/useSignTypedData.ts
+++ b/packages/react/src/hooks/accounts/useSignTypedData.ts
@@ -16,9 +16,8 @@ export type UseSignTypedDataConfig = MutationConfig<
   SignTypedDataArgs
 >
 
-export const mutationKey = (args: UseSignTypedDataArgs) => [
-  { entity: 'signTypedData', ...args },
-]
+export const mutationKey = (args: UseSignTypedDataArgs) =>
+  [{ entity: 'signTypedData', ...args }] as const
 
 const mutationFn = (args: UseSignTypedDataArgs) => {
   const { domain, types, value } = args


### PR DESCRIPTION
## Description

- Add `types` field to package.json
- Adds const assertion for mutation keys
- Remove separate `TypedDataDomain` and `TypedDataField` types and add into `SignTypedDataArgs`

Fixes #591

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
