### PR TITLE
Update useDapp status

### DIFF
--- a/docs/pages/docs/comparison.en-US.mdx
+++ b/docs/pages/docs/comparison.en-US.mdx
@@ -20,8 +20,8 @@ There are a multiple options when it comes to React libraries for Ethereum that 
 | Their Comparison     | –                                                                                         | none                                                                                                            | none                                                                                               | none                                                                                                    |
 | Supported Frameworks | React, Vanilla JS                                                                         | React                                                                                                           | React                                                                                              | Vanilla JS                                                                                              |
 | Documentation        | ✅                                                                                        | 🛑                                                                                                              | ✅                                                                                                 | 🛑                                                                                                      |
-| Test Suite[^1]       | ✅                                                                                        | 🔶                                                                                                              | 🔶                                                                                                 | 🛑                                                                                                      |
-| Examples[^2]         | ✅                                                                                        | 🔶                                                                                                              | 🛑                                                                                                 | 🔶                                                                                                      |
+| Test Suite[^1]       | ✅                                                                                        | 🔶                                                                                                              | ✅                                                                                                 | 🛑                                                                                                      |
+| Examples[^2]         | ✅                                                                                        | 🔶                                                                                                              | ✅                                                                                                 | 🔶                                                                                                      |
 
 ## [wagmi](https://github.com/tmm/wagmi)
 
@@ -66,10 +66,7 @@ There are a multiple options when it comes to React libraries for Ethereum that 
 
 ### Cons
 
-- Uses `web3-react`
 - Non-standard hook API
-- Lack of TypeScript generics support
-- Almost no tests
 
 ## [web3modal](https://github.com/Web3Modal/web3modal)
 


### PR DESCRIPTION
## Description

There are tests in [useDapp](https://github.com/TrueFiEng/useDApp/tree/master/packages/core/src/hooks).
We also have integration tests which use [playwright](https://playwright.dev/).

There is no web3react since version 1.*.

Our hooks have typechain support.

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
