### PR TITLE
feat: use domain.chainId to validate and switch chain before signing typed data

### DIFF
--- a/.changeset/lemon-bulldogs-live.md
+++ b/.changeset/lemon-bulldogs-live.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Use `domain.chainId` to validate and switch chain before signing in `useSignTypedData`.

--- a/.changeset/silly-dots-flow.md
+++ b/.changeset/silly-dots-flow.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+Use `domain.chainId` to validate and switch chain before signing in `signTypedData`.

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,8 @@ node_modules
 dist
 generated
 CHANGELOG.md
+
+// Once prettier fixes MDX ignore ranges
+// https://github.com/prettier/prettier/pull/12208
+docs/pages/index.en-US.mdx
+docs/pages/docs/getting-started.en-US.mdx

--- a/docs/pages/docs/getting-started.en-US.mdx
+++ b/docs/pages/docs/getting-started.en-US.mdx
@@ -6,11 +6,25 @@ import Callout from 'nextra-theme-docs/callout'
 
 Install wagmi and its ethers peer dependency.
 
+{/* prettier-ignore-start */}
 <Nextra.Tabs items={['npm', 'pnpm', 'yarn']}>
-  <Nextra.Tab>```bash npm i wagmi ethers ```</Nextra.Tab>
-  <Nextra.Tab>```bash pnpm i wagmi ethers ```</Nextra.Tab>
-  <Nextra.Tab>```bash yarn add wagmi ethers ```</Nextra.Tab>
+  <Nextra.Tab>
+```bash
+npm i wagmi ethers
+```
+  </Nextra.Tab>
+  <Nextra.Tab>
+```bash
+pnpm i wagmi ethers
+```
+  </Nextra.Tab>
+  <Nextra.Tab>
+```bash
+yarn add wagmi ethers
+```
+  </Nextra.Tab>
 </Nextra.Tabs>
+{/* prettier-ignore-end */}
 
 ## Quick Start
 

--- a/docs/pages/index.en-US.mdx
+++ b/docs/pages/index.en-US.mdx
@@ -8,13 +8,27 @@ import { Header } from '../components/docs'
 
 **wagmi** is a collection of React Hooks containing everything you need to start working with Ethereum. wagmi makes it easy to "Connect Wallet," display ENS and balance information, sign messages, interact with contracts, and much more — all with caching, request deduplication, and persistence.
 
+{/* prettier-ignore-start */}
 <div className="max-w-xs mx-auto mt-5 mb-8 text-center install">
   <Nextra.Tabs items={['npm', 'pnpm', 'yarn']}>
-    <Nextra.Tab>```bash npm i wagmi ethers ```</Nextra.Tab>
-    <Nextra.Tab>```bash pnpm i wagmi ethers ```</Nextra.Tab>
-    <Nextra.Tab>```bash yarn add wagmi ethers ```</Nextra.Tab>
+    <Nextra.Tab>
+```bash
+npm i wagmi ethers
+```
+    </Nextra.Tab>
+    <Nextra.Tab>
+```bash
+pnpm i wagmi ethers
+```
+    </Nextra.Tab>
+    <Nextra.Tab>
+```bash
+yarn add wagmi ethers
+```
+    </Nextra.Tab>
   </Nextra.Tabs>
 </div>
+{/* prettier-ignore-end */}
 
 <div className="mb-20 text-center">
   [Get Started](/docs/getting-started) · [Examples](/examples/connect-wallet) ·

--- a/packages/core/src/actions/accounts/signTypedData.test.ts
+++ b/packages/core/src/actions/accounts/signTypedData.test.ts
@@ -71,5 +71,33 @@ describe('signTypedData', () => {
         `"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"`,
       )
     })
+
+    describe('when chainId is provided in domain', () => {
+      it('switches before sending transaction', async () => {
+        await connect({ chainId: 4, connector })
+        expect(
+          await signTypedData({ domain, types, value }),
+        ).toMatchInlineSnapshot(
+          `"0x6ea8bb309a3401225701f3565e32519f94a0ea91a5910ce9229fe488e773584c0390416a2190d9560219dab757ecca2029e63fa9d1c2aebf676cc25b9f03126a1b"`,
+        )
+      })
+
+      it('unable to switch', async () => {
+        await connect({
+          chainId: 4,
+          connector: new MockConnector({
+            options: {
+              flags: { noSwitchChain: true },
+              signer: getSigners()[0]!,
+            },
+          }),
+        })
+        await expect(
+          signTypedData({ domain, types, value }),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Chain mismatch: Expected \\"Ethereum\\", received \\"Rinkeby."`,
+        )
+      })
+    })
   })
 })

--- a/packages/core/src/actions/accounts/signTypedData.ts
+++ b/packages/core/src/actions/accounts/signTypedData.ts
@@ -1,18 +1,25 @@
-import { BigNumberish, BytesLike, providers } from 'ethers'
+import { BytesLike, providers } from 'ethers'
 
+import { getClient } from '../../client'
 import {
+  ChainMismatchError,
   ConnectorNotFoundError,
   ProviderRpcError,
   UserRejectedRequestError,
 } from '../../errors'
-import { fetchSigner } from './fetchSigner'
+import { Chain } from '../../types'
+import { normalizeChainId } from '../../utils'
 
 export type SignTypedDataArgs = {
   /** Domain or domain signature for origin or contract */
   domain: {
     name?: string
     version?: string
-    chainId?: BigNumberish
+    /**
+     * Chain permitted for signing
+     * If signer is not active on this chain, it will attempt to programmatically switch
+     */
+    chainId?: string | number | bigint
     verifyingContract?: string
     salt?: BytesLike
   }
@@ -24,17 +31,41 @@ export type SignTypedDataArgs = {
 
 export type SignTypedDataResult = string
 
-export async function signTypedData(
-  args: SignTypedDataArgs,
-): Promise<SignTypedDataResult> {
+export async function signTypedData({
+  domain,
+  types,
+  value,
+}: SignTypedDataArgs): Promise<SignTypedDataResult> {
+  const { connector } = getClient()
+  if (!connector) throw new ConnectorNotFoundError()
+
   try {
-    const signer = await fetchSigner()
-    if (!signer) throw new ConnectorNotFoundError()
+    const { chainId } = domain
+    let chain: Chain | undefined
+    if (chainId) {
+      const chainId_ = normalizeChainId(chainId)
+      const activeChainId = await connector.getChainId()
+      // Try to switch chain to provided `chainId`
+      if (chainId !== activeChainId) {
+        if (connector.switchChain) chain = await connector.switchChain(chainId_)
+        else
+          throw new ChainMismatchError({
+            activeChain:
+              connector.chains.find((x) => x.id === activeChainId)?.name ??
+              `Chain ${activeChainId}`,
+            targetChain:
+              connector.chains.find((x) => x.id === chainId_)?.name ??
+              `Chain ${chainId_}`,
+          })
+      }
+    }
+
+    const signer = await connector.getSigner({ chainId: chain?.id })
     // Method name may be changed in the future, see https://docs.ethers.io/v5/api/signer/#Signer-signTypedData
     return await (<providers.JsonRpcSigner>signer)._signTypedData(
-      args.domain,
-      args.types,
-      args.value,
+      domain,
+      types,
+      value,
     )
   } catch (error) {
     if ((<ProviderRpcError>error).code === 4001)

--- a/packages/core/src/utils/normalizeChainId.test.ts
+++ b/packages/core/src/utils/normalizeChainId.test.ts
@@ -1,15 +1,17 @@
 import { normalizeChainId } from './normalizeChainId'
 
 describe.each`
-  chainId    | expected
-  ${1}       | ${1}
-  ${'1'}     | ${1}
-  ${'0x1'}   | ${1}
-  ${'0x4'}   | ${4}
-  ${42}      | ${42}
-  ${'42'}    | ${42}
-  ${'0x2a'}  | ${42}
-  ${' 0x2a'} | ${42}
+  chainId       | expected
+  ${1}          | ${1}
+  ${'1'}        | ${1}
+  ${'0x1'}      | ${1}
+  ${'0x4'}      | ${4}
+  ${42}         | ${42}
+  ${'42'}       | ${42}
+  ${'0x2a'}     | ${42}
+  ${' 0x2a'}    | ${42}
+  ${BigInt(1)}  | ${1}
+  ${BigInt(10)} | ${10}
 `('normalizeChainId($chainId)', ({ chainId, expected }) => {
   it(`returns ${expected}`, () => {
     expect(normalizeChainId(chainId)).toEqual(expected)

--- a/packages/core/src/utils/normalizeChainId.ts
+++ b/packages/core/src/utils/normalizeChainId.ts
@@ -1,8 +1,9 @@
-export function normalizeChainId(chainId: string | number) {
+export function normalizeChainId(chainId: string | number | bigint) {
   if (typeof chainId === 'string')
     return Number.parseInt(
       chainId,
       chainId.trim().substring(0, 2) === '0x' ? 16 : 10,
     )
+  if (typeof chainId === 'bigint') return Number(chainId)
   return chainId
 }

--- a/packages/react/src/hooks/contracts/useContractWrite.test.ts
+++ b/packages/react/src/hooks/contracts/useContractWrite.test.ts
@@ -60,12 +60,12 @@ describe('useContractWrite', () => {
         const utils = renderHook(() =>
           useContractWriteWithConnect({
             ...mlootContractConfig,
+            chainId: 1,
             functionName: 'claim',
-            chainId: 10,
           }),
         )
         const { result, waitFor } = utils
-        await actConnect({ utils, connector })
+        await actConnect({ chainId: 4, connector, utils })
 
         await act(async () => {
           result.current.contractWrite.write()
@@ -76,7 +76,7 @@ describe('useContractWrite', () => {
         )
 
         expect(result.current.contractWrite.error).toMatchInlineSnapshot(
-          `[ChainMismatchError: Chain mismatch: Expected "Chain 10", received "Ethereum.]`,
+          `[ChainMismatchError: Chain mismatch: Expected "Ethereum", received "Rinkeby.]`,
         )
       })
     })

--- a/packages/react/src/hooks/transactions/useSendTransaction.test.ts
+++ b/packages/react/src/hooks/transactions/useSendTransaction.test.ts
@@ -51,7 +51,7 @@ describe('useSendTransaction', () => {
           }),
         )
         const { result, waitFor } = utils
-        await actConnect({ utils })
+        await actConnect({ chainId: 4, utils })
 
         await act(async () => {
           result.current.sendTransaction.sendTransaction()
@@ -98,7 +98,7 @@ describe('useSendTransaction', () => {
         })
         const utils = renderHook(() =>
           useSendTransactionWithConnect({
-            chainId: 10,
+            chainId: 1,
             request: {
               to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
               value: parseEther('1'),
@@ -106,7 +106,7 @@ describe('useSendTransaction', () => {
           }),
         )
         const { result, waitFor } = utils
-        await actConnect({ utils, connector })
+        await actConnect({ chainId: 4, connector, utils })
 
         await act(async () => {
           result.current.sendTransaction.sendTransaction()
@@ -117,7 +117,7 @@ describe('useSendTransaction', () => {
         )
 
         expect(result.current.sendTransaction.error).toMatchInlineSnapshot(
-          `[ChainMismatchError: Chain mismatch: Expected "Chain 10", received "Ethereum.]`,
+          `[ChainMismatchError: Chain mismatch: Expected "Ethereum", received "Rinkeby.]`,
         )
       })
     })

--- a/packages/react/test/utils.ts
+++ b/packages/react/test/utils.ts
@@ -30,6 +30,7 @@ export function setupClient(config: Config = {}) {
 }
 
 export async function actConnect(config: {
+  chainId?: number
   connector?: Connector
   utils: ReturnType<typeof renderHook>
 }) {
@@ -41,6 +42,7 @@ export async function actConnect(config: {
   await act(async () => {
     const connect = getConnect(utils)
     await connect.connectAsync?.({
+      chainId: config.chainId,
       connector: connector ?? connect.connectors?.[0],
     })
   })


### PR DESCRIPTION
## Description

 Use `domain.chainId` to validate and switch chain before signing in `useSignTypedData`. Similar to https://github.com/tmm/wagmi/pull/611

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth