### PR TITLE
Fixed type error for webSocketProvider

### DIFF
--- a/packages/core/src/utils/configureChains.ts
+++ b/packages/core/src/utils/configureChains.ts
@@ -112,10 +112,14 @@ export function configureChains<
 
       if (!chainWebSocketProviders) return undefined
       if (chainWebSocketProviders.length === 1)
-        return Object.assign(chainWebSocketProviders[0]?.() || {}, { chains })
+        return Object.assign(chainWebSocketProviders[0]?.() || {}, {
+          chains,
+        }) as TWebSocketProvider & { chains: TChain[] }
       // WebSockets do not work with `fallbackProvider`
       // Default to first available
-      return Object.assign(chainWebSocketProviders[0]?.() || {}, { chains })
+      return Object.assign(chainWebSocketProviders[0]?.() || {}, {
+        chains,
+      }) as TWebSocketProvider & { chains: TChain[] }
     },
   } as const
 }


### PR DESCRIPTION
## Description

With the introduction of wagmi 0.5.0 I began to experience a type error when passing a webSocketProvider to a client instance. I attempted to fix this type error by explicitly casting the types of TWebSocketProvider and TChain[] to the return values of webSocketProvider in configureChains.ts

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: braeden.eth
