### PR TITLE
fix: `useSyncExternalStoreWithTracked` equalityFn should return truthy when there are no tracked keys

### DIFF
--- a/.changeset/thick-doors-bow.md
+++ b/.changeset/thick-doors-bow.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+equalityFn in `useSyncExternalStoreWithTracked` should return truthy when there are no tracked keys.

--- a/packages/react/src/hooks/accounts/useAccount.test.ts
+++ b/packages/react/src/hooks/accounts/useAccount.test.ts
@@ -4,19 +4,15 @@ import {
   actDisconnect,
   renderHook,
   setupClient,
+  useAccount,
 } from '../../../test'
-import { UseAccountConfig, useAccount } from './useAccount'
+import { UseAccountConfig } from './useAccount'
 import { useConnect } from './useConnect'
 import { useDisconnect } from './useDisconnect'
 
-function useTestAccount(config: UseAccountConfig = {}) {
-  const { ...values } = useAccount(config)
-  return values
-}
-
 function useAccountWithConnectAndDisconnect(config: UseAccountConfig = {}) {
   return {
-    account: useTestAccount(config),
+    account: useAccount(config),
     connect: useConnect(),
     disconnect: useDisconnect(),
   }

--- a/packages/react/src/hooks/accounts/useAccount.test.ts
+++ b/packages/react/src/hooks/accounts/useAccount.test.ts
@@ -9,9 +9,14 @@ import { UseAccountConfig, useAccount } from './useAccount'
 import { useConnect } from './useConnect'
 import { useDisconnect } from './useDisconnect'
 
+function useTestAccount(config: UseAccountConfig = {}) {
+  const { ...values } = useAccount(config)
+  return values
+}
+
 function useAccountWithConnectAndDisconnect(config: UseAccountConfig = {}) {
   return {
-    account: useAccount(config),
+    account: useTestAccount(config),
     connect: useConnect(),
     disconnect: useDisconnect(),
   }

--- a/packages/react/src/hooks/accounts/useConnect.test.ts
+++ b/packages/react/src/hooks/accounts/useConnect.test.ts
@@ -1,7 +1,6 @@
 import { MockConnector } from '@wagmi/core/connectors/mock'
 
-import { act, getSigners, renderHook } from '../../../test'
-import { useAccount } from './useAccount'
+import { act, getSigners, renderHook, useAccount } from '../../../test'
 import { UseConnectArgs, UseConnectConfig, useConnect } from './useConnect'
 
 const connector = new MockConnector({
@@ -15,14 +14,9 @@ const connectorFail = new MockConnector({
   },
 })
 
-function useTestAccount() {
-  const { ...values } = useAccount()
-  return values
-}
-
 function useConnectWithAccount(config: UseConnectArgs & UseConnectConfig = {}) {
   return {
-    account: useTestAccount(),
+    account: useAccount(),
     connect: useConnect(config),
   }
 }

--- a/packages/react/src/hooks/accounts/useConnect.test.ts
+++ b/packages/react/src/hooks/accounts/useConnect.test.ts
@@ -15,9 +15,14 @@ const connectorFail = new MockConnector({
   },
 })
 
+function useTestAccount() {
+  const { ...values } = useAccount()
+  return values
+}
+
 function useConnectWithAccount(config: UseConnectArgs & UseConnectConfig = {}) {
   return {
-    account: useAccount(),
+    account: useTestAccount(),
     connect: useConnect(config),
   }
 }

--- a/packages/react/src/hooks/accounts/useDisconnect.test.ts
+++ b/packages/react/src/hooks/accounts/useDisconnect.test.ts
@@ -3,13 +3,18 @@ import { useAccount } from './useAccount'
 import { useConnect } from './useConnect'
 import { UseDisconnectConfig, useDisconnect } from './useDisconnect'
 
+function useTestAccount() {
+  const { ...values } = useAccount()
+  return values
+}
+
 function useDisconnectWithConnect(config: UseDisconnectConfig = {}) {
   return { connect: useConnect(), disconnect: useDisconnect(config) }
 }
 
 function useDisconnectWithAccountAndConnect() {
   return {
-    account: useAccount(),
+    account: useTestAccount(),
     connect: useConnect(),
     disconnect: useDisconnect(),
   }

--- a/packages/react/src/hooks/accounts/useDisconnect.test.ts
+++ b/packages/react/src/hooks/accounts/useDisconnect.test.ts
@@ -1,12 +1,6 @@
-import { act, actConnect, renderHook } from '../../../test'
-import { useAccount } from './useAccount'
+import { act, actConnect, renderHook, useAccount } from '../../../test'
 import { useConnect } from './useConnect'
 import { UseDisconnectConfig, useDisconnect } from './useDisconnect'
-
-function useTestAccount() {
-  const { ...values } = useAccount()
-  return values
-}
 
 function useDisconnectWithConnect(config: UseDisconnectConfig = {}) {
   return { connect: useConnect(), disconnect: useDisconnect(config) }
@@ -14,7 +8,7 @@ function useDisconnectWithConnect(config: UseDisconnectConfig = {}) {
 
 function useDisconnectWithAccountAndConnect() {
   return {
-    account: useTestAccount(),
+    account: useAccount(),
     connect: useConnect(),
     disconnect: useDisconnect(),
   }

--- a/packages/react/src/hooks/accounts/useNetwork.test.ts
+++ b/packages/react/src/hooks/accounts/useNetwork.test.ts
@@ -6,20 +6,15 @@ import {
   actSwitchNetwork,
   renderHook,
   setupClient,
+  useNetwork,
 } from '../../../test'
 import { UseConnectArgs, UseConnectConfig, useConnect } from './useConnect'
 import { useDisconnect } from './useDisconnect'
-import { useNetwork } from './useNetwork'
 import {
   UseSwitchNetworkArgs,
   UseSwitchNetworkConfig,
   useSwitchNetwork,
 } from './useSwitchNetwork'
-
-function useTestNetwork() {
-  const { ...values } = useNetwork()
-  return values
-}
 
 function useNetworkWithConnectAndDisconnect(
   config: {
@@ -30,7 +25,7 @@ function useNetworkWithConnectAndDisconnect(
   return {
     connect: useConnect(config.connect),
     disconnect: useDisconnect(),
-    network: useTestNetwork(),
+    network: useNetwork(),
     switchNetwork: useSwitchNetwork(config.switchNetwork),
   }
 }
@@ -41,7 +36,7 @@ describe('useNetwork', () => {
       const client = setupClient()
       await connect({ connector: client.connectors[0]! })
 
-      const { result } = renderHook(() => useTestNetwork(), {
+      const { result } = renderHook(() => useNetwork(), {
         initialProps: { client },
       })
 

--- a/packages/react/src/hooks/accounts/useNetwork.test.ts
+++ b/packages/react/src/hooks/accounts/useNetwork.test.ts
@@ -16,6 +16,11 @@ import {
   useSwitchNetwork,
 } from './useSwitchNetwork'
 
+function useTestNetwork() {
+  const { ...values } = useNetwork()
+  return values
+}
+
 function useNetworkWithConnectAndDisconnect(
   config: {
     connect?: UseConnectArgs & UseConnectConfig
@@ -25,7 +30,7 @@ function useNetworkWithConnectAndDisconnect(
   return {
     connect: useConnect(config.connect),
     disconnect: useDisconnect(),
-    network: useNetwork(),
+    network: useTestNetwork(),
     switchNetwork: useSwitchNetwork(config.switchNetwork),
   }
 }
@@ -36,7 +41,7 @@ describe('useNetwork', () => {
       const client = setupClient()
       await connect({ connector: client.connectors[0]! })
 
-      const { result } = renderHook(() => useNetwork(), {
+      const { result } = renderHook(() => useTestNetwork(), {
         initialProps: { client },
       })
 

--- a/packages/react/src/hooks/utils/useSyncExternalStoreWithTracked.test.tsx
+++ b/packages/react/src/hooks/utils/useSyncExternalStoreWithTracked.test.tsx
@@ -37,45 +37,7 @@ function useExternalStore(
 }
 
 describe('useSyncExternalStoreWithTracked', () => {
-  it('rerenders when any property changes', async () => {
-    const externalStore = createExternalStore({
-      foo: 'bar',
-      baz: 'wagmi',
-      isGonnaMakeIt: false,
-    })
-
-    const renders: any[] = []
-
-    function App() {
-      const state = useExternalStore(externalStore, (state) =>
-        renders.push(state),
-      )
-      return <div>{JSON.stringify(state)}</div>
-    }
-
-    render(wrapper({ children: <App /> }), document.createElement('div'))
-
-    act(() => {
-      externalStore.set((x) => ({ ...x, isGonnaMakeIt: true }))
-    })
-
-    expect(renders).toMatchInlineSnapshot(`
-      [
-        {
-          "baz": "wagmi",
-          "foo": "bar",
-          "isGonnaMakeIt": false,
-        },
-        {
-          "baz": "wagmi",
-          "foo": "bar",
-          "isGonnaMakeIt": true,
-        },
-      ]
-    `)
-  })
-
-  it('rerenders only when `baz` changes', async () => {
+  it('rerenders only when the tracked value changes', async () => {
     const externalStore = createExternalStore({
       foo: 'bar',
       baz: 'wagmi',
@@ -122,6 +84,81 @@ describe('useSyncExternalStoreWithTracked', () => {
           "baz": "ngmi",
           "foo": "baz",
           "isGonnaMakeIt": true,
+        },
+      ]
+    `)
+  })
+
+  it('rerenders when all values are being tracked', async () => {
+    const externalStore = createExternalStore({
+      foo: 'bar',
+      baz: 'wagmi',
+      isGonnaMakeIt: false,
+    })
+
+    const renders: any[] = []
+
+    function App() {
+      const state = useExternalStore(externalStore, (state) =>
+        renders.push(state),
+      )
+      return (
+        <div>
+          {state.baz}
+          {state.foo}
+          {state.isGonnaMakeIt}
+        </div>
+      )
+    }
+
+    render(wrapper({ children: <App /> }), document.createElement('div'))
+
+    act(() => {
+      externalStore.set((x) => ({ ...x, isGonnaMakeIt: true }))
+    })
+
+    expect(renders).toMatchInlineSnapshot(`
+      [
+        {
+          "baz": "wagmi",
+          "foo": "bar",
+          "isGonnaMakeIt": false,
+        },
+        {
+          "baz": "wagmi",
+          "foo": "bar",
+          "isGonnaMakeIt": true,
+        },
+      ]
+    `)
+  })
+
+  it('does not rerender when no values are being tracked', async () => {
+    const externalStore = createExternalStore({
+      foo: 'bar',
+      baz: 'wagmi',
+      isGonnaMakeIt: false,
+    })
+
+    const renders: any[] = []
+
+    function App() {
+      useExternalStore(externalStore, (state) => renders.push(state))
+      return <div>test</div>
+    }
+
+    render(wrapper({ children: <App /> }), document.createElement('div'))
+
+    act(() => {
+      externalStore.set((x) => ({ ...x, isGonnaMakeIt: true }))
+    })
+
+    expect(renders).toMatchInlineSnapshot(`
+      [
+        {
+          "baz": "wagmi",
+          "foo": "bar",
+          "isGonnaMakeIt": false,
         },
       ]
     `)

--- a/packages/react/src/hooks/utils/useSyncExternalStoreWithTracked.ts
+++ b/packages/react/src/hooks/utils/useSyncExternalStoreWithTracked.ts
@@ -22,11 +22,7 @@ export function useSyncExternalStoreWithTracked<
     getServerSnapshot,
     (x) => x,
     (a, b) => {
-      if (
-        isPlainObject(a) &&
-        isPlainObject(b) &&
-        trackedKeys.current.length > 0
-      ) {
+      if (isPlainObject(a) && isPlainObject(b)) {
         for (const key of trackedKeys.current) {
           const equal = isEqual(
             (a as { [key: string]: any })[key],

--- a/packages/react/test/index.tsx
+++ b/packages/react/test/index.tsx
@@ -74,6 +74,8 @@ export {
   actDisconnect,
   actSwitchNetwork,
   getUnclaimedTokenId,
+  useAccount,
+  useNetwork,
 } from './utils'
 export {
   getProvider,

--- a/packages/react/test/utils.ts
+++ b/packages/react/test/utils.ts
@@ -118,6 +118,11 @@ export async function getUnclaimedTokenId(
   return false
 }
 
+/**
+ * `renderHook` in `@testing-library/react` doesn't play well
+ * with tracked values, so we need to use custom hooks.
+ */
+
 export function useAccount(config: UseAccountConfig = {}) {
   const { ...values } = useAccount_(config)
   return values

--- a/packages/react/test/utils.ts
+++ b/packages/react/test/utils.ts
@@ -12,6 +12,11 @@ import {
 import { getProvider, getSigners } from '../../core/test/utils'
 import { renderHook } from '.'
 import { CreateClientConfig, createClient } from '../src'
+import {
+  UseAccountConfig,
+  useAccount as useAccount_,
+} from '../src/hooks/accounts/useAccount'
+import { useNetwork as useNetwork_ } from '../src/hooks/accounts/useNetwork'
 
 type Config = Partial<CreateClientConfig>
 
@@ -111,4 +116,14 @@ export async function getUnclaimedTokenId(
     attempts += 1
   }
   return false
+}
+
+export function useAccount(config: UseAccountConfig = {}) {
+  const { ...values } = useAccount_(config)
+  return values
+}
+
+export function useNetwork() {
+  const { ...values } = useNetwork_()
+  return values
 }


### PR DESCRIPTION
## Description

_Concise description of proposed changes_

## Additional Information

- [ ] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
