### PR TITLE
remove client(optional) as it is required since 0.5.x

### DIFF
--- a/docs/pages/docs/WagmiConfig.en-US.mdx
+++ b/docs/pages/docs/WagmiConfig.en-US.mdx
@@ -27,7 +27,7 @@ function App() {
 
 ## Configuration
 
-### client (optional)
+### client
 
 A wagmi [`Client`](/docs/client) instance that consists of configuration options. Defaults to `createClient()`.
 


### PR DESCRIPTION
## Description

[Migration guide](https://wagmi.sh/docs/migration-guide#05x-breaking-changes) states that `client` is now required. Docs are stale on previous versions stating is it optional

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: `harry.eth`
