### PR TITLE
Use correct chainId in Foundry chain definition

### DIFF
--- a/packages/core/src/constants/chains.ts
+++ b/packages/core/src/constants/chains.ts
@@ -309,7 +309,7 @@ export const hardhat: Chain = {
 }
 
 export const foundry: Chain = {
-  id: chainId.hardhat,
+  id: chainId.foundry,
   name: 'Foundry',
   network: 'foundry',
   rpcUrls: {


### PR DESCRIPTION
## Description

Small fix to update the `id` definition for the chain `foundry` as it was using `chainId.hardhat` instead of `chainId.foundry`.

Possibly worth mentioning that the values are the same for `hardhat` and `foundry` in the [`chainId` constant](https://github.com/tmm/wagmi/blob/e4bd79fe8da24e80100515c516a358ccdd71509a/packages/core/src/constants/chains.ts#L18-L19), not sure if these IDs are actually supposed to be the same. 🤷‍♀️
```
hardhat: 31_337,
foundry: 31_337,
```

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: `lochie.eth`
