### PR TITLE
Update useNetwork.en-US.mdx

### DIFF
--- a/docs/pages/docs/hooks/useNetwork.en-US.mdx
+++ b/docs/pages/docs/hooks/useNetwork.en-US.mdx
@@ -17,11 +17,11 @@ import { useNetwork } from 'wagmi'
 import { useNetwork } from 'wagmi'
 
 function App() {
-  const { chain, chains } = useNetwork()
+  const { activeChain, chains } = useNetwork()
 
   return (
     <>
-      {chain && <div>Connected to {chain.name}</div>}
+      {activeChain && <div>Connected to {activeChain.name}</div>}
       {chains && (
         <div>Available chains: {chains.map((chain) => chain.name)}</div>
       )}
@@ -36,7 +36,7 @@ function App() {
 
 ```tsx
 {
-  chain?: Chain & { unsupported?: boolean }
+  activeChain?: Chain & { unsupported?: boolean }
   chains: Chain[]
 }
 ```


### PR DESCRIPTION
## Description

According to the documentation, `chain` is one of `useNetwork()`'s return values. However, I realised that it doesn't return `chain`, but returns `activeChain` instead. Therefore, using what's currently in the documentation will result in an error.

So, I updated the documentation to fix this.

### Documentation

<img width="918" alt="Screenshot 2022-07-01 at 15 36 35" src="https://user-images.githubusercontent.com/23613565/176916781-81317ebc-0ec8-4b63-8495-6bd096d43837.png">

### Actual Return Value

<img width="741" alt="Screenshot 2022-07-01 at 15 39 15" src="https://user-images.githubusercontent.com/23613565/176916960-baf6250d-43fd-4454-b936-fc444a876af0.png">

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: tjelailah.eth
