### PR TITLE
fix: fix multicall returning nullish data for all calls unexpectedly

### DIFF
--- a/.changeset/mighty-mice-sip.md
+++ b/.changeset/mighty-mice-sip.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+omit `contractInterface` from `useContractRead` & `useContractReads` query key hash

--- a/.changeset/slow-pumpkins-love.md
+++ b/.changeset/slow-pumpkins-love.md
@@ -1,0 +1,6 @@
+---
+'@wagmi/core': patch
+'wagmi': patch
+---
+
+fix `multicall` returning nullish data for all calls unexpectedly

--- a/.config/hardhat.config.ts
+++ b/.config/hardhat.config.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import { HardhatUserConfig } from 'hardhat/config'
 
 const config: HardhatUserConfig = {

--- a/examples/_dev/src/components/Account.tsx
+++ b/examples/_dev/src/components/Account.tsx
@@ -5,6 +5,7 @@ import { useIsMounted } from '../hooks'
 import { Balance } from './Balance'
 import { BlockNumber } from './BlockNumber'
 import { ReadContract } from './ReadContract'
+import { ReadContracts } from './ReadContracts'
 import { SendTransaction } from './SendTransaction'
 import { SignMessage } from './SignMessage'
 import { Token } from './Token'
@@ -60,6 +61,9 @@ export const Account = () => {
 
           <h4>Read Contract</h4>
           <ReadContract />
+
+          <h4>Read Contracts</h4>
+          <ReadContracts />
 
           <h4>Write Contract</h4>
           <WriteContract />

--- a/examples/_dev/src/components/ReadContract.tsx
+++ b/examples/_dev/src/components/ReadContract.tsx
@@ -17,13 +17,11 @@ export const ReadContract = () => {
 }
 
 const GetAlive = () => {
-  const { data, isRefetching, isSuccess, refetch } = useContractRead(
-    {
-      addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
-      contractInterface: wagmigotchiABI,
-    },
-    'getAlive',
-  )
+  const { data, isRefetching, isSuccess, refetch } = useContractRead({
+    addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+    contractInterface: wagmigotchiABI,
+    functionName: 'getAlive',
+  })
 
   return (
     <div>
@@ -41,14 +39,13 @@ const GetAlive = () => {
 
 const Love = () => {
   const [address, setAddress] = useState<string>('')
-  const { data, isFetching, isRefetching, isSuccess } = useContractRead(
-    {
-      addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
-      contractInterface: wagmigotchiABI,
-    },
-    'love',
-    { args: [address], enabled: Boolean(address) },
-  )
+  const { data, isFetching, isRefetching, isSuccess } = useContractRead({
+    addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+    contractInterface: wagmigotchiABI,
+    functionName: 'love',
+    args: [address],
+    enabled: Boolean(address),
+  })
 
   const [value, setValue] = useState('')
 

--- a/examples/_dev/src/components/ReadContracts.tsx
+++ b/examples/_dev/src/components/ReadContracts.tsx
@@ -1,0 +1,68 @@
+import { useContractReads } from 'wagmi'
+
+export const wagmigotchiContractConfig = {
+  addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
+  contractInterface: [
+    {
+      inputs: [],
+      name: 'getAlive',
+      outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+      stateMutability: 'view',
+      type: 'function',
+    },
+    {
+      inputs: [{ internalType: 'address', name: '', type: 'address' }],
+      name: 'love',
+      outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+      stateMutability: 'view',
+      type: 'function',
+    },
+  ],
+}
+
+export const mlootContractConfig = {
+  addressOrName: '0x1dfe7ca09e99d10835bf73044a23b73fc20623df',
+  contractInterface: [
+    {
+      inputs: [
+        { internalType: 'address', name: 'owner', type: 'address' },
+        { internalType: 'uint256', name: 'index', type: 'uint256' },
+      ],
+      name: 'tokenOfOwnerByIndex',
+      outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+      stateMutability: 'view',
+      type: 'function',
+    },
+  ],
+}
+
+export function ReadContracts() {
+  const { data, isSuccess, isLoading } = useContractReads({
+    contracts: [
+      {
+        ...wagmigotchiContractConfig,
+        functionName: 'love',
+        args: '0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c',
+      },
+      {
+        ...wagmigotchiContractConfig,
+        functionName: 'love',
+        args: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+      },
+      { ...wagmigotchiContractConfig, functionName: 'getAlive' },
+      {
+        ...mlootContractConfig,
+        functionName: 'tokenOfOwnerByIndex',
+        args: ['0xA0Cf798816D4b9b9866b5330EEa46a18382f251e', 0],
+      },
+    ],
+  })
+
+  return (
+    <div>
+      <div>Data:</div>
+      {isLoading && <div>loading...</div>}
+      {isSuccess && data?.map((data) => <div>{JSON.stringify(data)}</div>)}
+    </div>
+  )
+}

--- a/examples/_dev/src/pages/_app.tsx
+++ b/examples/_dev/src/pages/_app.tsx
@@ -35,6 +35,10 @@ const avalanche: Chain = {
   rpcUrls: {
     default: 'https://api.avax.network/ext/bc/C/rpc',
   },
+  multicall: {
+    address: '0xca11bde05977b3631167028862be2a173976ca11',
+    blockCreated: 11907934,
+  },
   blockExplorers: {
     default: { name: 'SnowTrace', url: 'https://snowtrace.io' },
   },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
     "bundlewatch": "^0.3.3",
+    "dotenv": "^11.0.0",
     "eslint": "8.17.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^2.7.1",

--- a/packages/core/src/actions/contracts/multicall.test.ts
+++ b/packages/core/src/actions/contracts/multicall.test.ts
@@ -26,12 +26,13 @@ const contracts: MulticallConfig['contracts'] = [
   },
 ]
 
-describe('readContracts', () => {
-  beforeEach(() =>
+describe('multicall', () => {
+  beforeEach(() => {
     setupClient({
       chains: [chain.mainnet, { ...chain.polygon, multicall: undefined }],
-    }),
-  )
+    })
+    console.warn = jest.fn()
+  })
 
   it('default', async () => {
     expect(await multicall({ contracts })).toMatchInlineSnapshot(`
@@ -95,22 +96,83 @@ describe('readContracts', () => {
       `)
     })
 
-    it('allowFailure', async () => {
-      await expect(
-        multicall({
-          allowFailure: false,
-          contracts: [
-            ...contracts,
+    describe('allowFailure', () => {
+      it('it should throw if a contract method fails', async () => {
+        await expect(
+          multicall({
+            allowFailure: false,
+            contracts: [
+              ...contracts,
+              {
+                ...mlootContractConfig,
+                functionName: 'tokenOfOwnerByIndex',
+                args: ['0xA0Cf798816D4b9b9866b5330EEa46a18382f251e', 69420],
+              },
+            ],
+          }),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"call revert exception; VM Exception while processing transaction: reverted with reason string \\"Multicall3: call failed\\" [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ] (method=\\"aggregate3((address,bool,bytes)[])\\", data=\\"0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000174d756c746963616c6c333a2063616c6c206661696c6564000000000000000000\\", errorArgs=[\\"Multicall3: call failed\\"], errorName=\\"Error\\", errorSignature=\\"Error(string)\\", reason=\\"Multicall3: call failed\\", code=CALL_EXCEPTION, version=abi/5.6.1)"`,
+        )
+      })
+
+      it('should not throw if allowFailure=true & a contract has no response', async () => {
+        expect(
+          await multicall({
+            allowFailure: true,
+            contracts: [
+              ...contracts,
+              {
+                ...wagmigotchiContractConfig,
+                functionName: 'love',
+                // address is not the wagmigotchi contract
+                addressOrName: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+                args: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              },
+            ],
+          }),
+        ).toMatchInlineSnapshot(`
+          [
             {
-              ...mlootContractConfig,
-              functionName: 'tokenOfOwnerByIndex',
-              args: ['0xA0Cf798816D4b9b9866b5330EEa46a18382f251e', 69420],
+              "hex": "0x02",
+              "type": "BigNumber",
             },
-          ],
-        }),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"call revert exception; VM Exception while processing transaction: reverted with reason string \\"Multicall3: call failed\\" [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ] (method=\\"aggregate3((address,bool,bytes)[])\\", data=\\"0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000174d756c746963616c6c333a2063616c6c206661696c6564000000000000000000\\", errorArgs=[\\"Multicall3: call failed\\"], errorName=\\"Error\\", errorSignature=\\"Error(string)\\", reason=\\"Multicall3: call failed\\", code=CALL_EXCEPTION, version=abi/5.6.1)"`,
-      )
+            {
+              "hex": "0x01",
+              "type": "BigNumber",
+            },
+            false,
+            {
+              "hex": "0x05a6db",
+              "type": "BigNumber",
+            },
+            undefined,
+          ]
+        `)
+      })
+
+      it('should throw if allowFailure=false & a contract has no response', async () => {
+        await expect(
+          multicall({
+            allowFailure: false,
+            contracts: [
+              ...contracts,
+              {
+                ...wagmigotchiContractConfig,
+                functionName: 'love',
+                // address is not the wagmigotchi contract
+                addressOrName: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+                args: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              },
+            ],
+          }),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(`
+                "Function \\"love\\" on contract \\"0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC\\" returned an empty response.
+
+                Are you sure the function \\"love\\" exists on this contract?
+
+                Etherscan: https://etherscan.io/address/0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC#readContract"
+              `)
+      })
     })
   })
 

--- a/packages/core/src/actions/contracts/multicall.test.ts
+++ b/packages/core/src/actions/contracts/multicall.test.ts
@@ -115,7 +115,31 @@ describe('multicall', () => {
         )
       })
 
-      it('should not throw if allowFailure=true & a contract has no response', async () => {
+      it('throws if allowFailure=false & a contract has no response', async () => {
+        await expect(
+          multicall({
+            allowFailure: false,
+            contracts: [
+              ...contracts,
+              {
+                ...wagmigotchiContractConfig,
+                functionName: 'love',
+                // address is not the wagmigotchi contract
+                addressOrName: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+                args: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              },
+            ],
+          }),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(`
+                "Function \\"love\\" on contract \\"0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC\\" returned an empty response.
+
+                Are you sure the function \\"love\\" exists on this contract?
+
+                Etherscan: https://etherscan.io/address/0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC#readContract"
+              `)
+      })
+
+      it('does not throw if allowFailure=true & a contract has no response', async () => {
         expect(
           await multicall({
             allowFailure: true,
@@ -148,30 +172,6 @@ describe('multicall', () => {
             undefined,
           ]
         `)
-      })
-
-      it('should throw if allowFailure=false & a contract has no response', async () => {
-        await expect(
-          multicall({
-            allowFailure: false,
-            contracts: [
-              ...contracts,
-              {
-                ...wagmigotchiContractConfig,
-                functionName: 'love',
-                // address is not the wagmigotchi contract
-                addressOrName: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-                args: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-              },
-            ],
-          }),
-        ).rejects.toThrowErrorMatchingInlineSnapshot(`
-                "Function \\"love\\" on contract \\"0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC\\" returned an empty response.
-
-                Are you sure the function \\"love\\" exists on this contract?
-
-                Etherscan: https://etherscan.io/address/0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC#readContract"
-              `)
       })
     })
   })

--- a/packages/core/src/actions/contracts/readContracts.test.ts
+++ b/packages/core/src/actions/contracts/readContracts.test.ts
@@ -9,6 +9,25 @@ import * as readContract from './readContract'
 import * as multicall from './multicall'
 import { chain } from '../../constants'
 
+const contracts: ReadContractsConfig['contracts'] = [
+  {
+    ...wagmigotchiContractConfig,
+    functionName: 'love',
+    args: '0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c',
+  },
+  {
+    ...wagmigotchiContractConfig,
+    functionName: 'love',
+    args: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+  },
+  { ...wagmigotchiContractConfig, functionName: 'getAlive' },
+  {
+    ...mlootContractConfig,
+    functionName: 'tokenOfOwnerByIndex',
+    args: ['0xA0Cf798816D4b9b9866b5330EEa46a18382f251e', 0],
+  },
+]
+
 describe('readContracts', () => {
   beforeEach(() => {
     setupClient({
@@ -19,24 +38,6 @@ describe('readContracts', () => {
 
   it('default', async () => {
     const spy = jest.spyOn(multicall, 'multicall')
-    const contracts: ReadContractsConfig['contracts'] = [
-      {
-        ...wagmigotchiContractConfig,
-        functionName: 'love',
-        args: '0x27a69ffba1e939ddcfecc8c7e0f967b872bac65c',
-      },
-      {
-        ...wagmigotchiContractConfig,
-        functionName: 'love',
-        args: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-      },
-      { ...wagmigotchiContractConfig, functionName: 'getAlive' },
-      {
-        ...mlootContractConfig,
-        functionName: 'tokenOfOwnerByIndex',
-        args: ['0xA0Cf798816D4b9b9866b5330EEa46a18382f251e', 0],
-      },
-    ]
     const results = await readContracts({ contracts })
 
     expect(spy).toHaveBeenCalledWith({
@@ -182,6 +183,7 @@ describe('readContracts', () => {
         ]
       `)
     })
+
     it('falls back to readContract if multicall is not available', async () => {
       const spy = jest.spyOn(readContract, 'readContract')
       const ethContracts: ReadContractsConfig['contracts'] = [
@@ -238,6 +240,85 @@ describe('readContracts', () => {
           },
         ]
       `)
+    })
+  })
+
+  describe('allowFailure', () => {
+    it('it should throw if a contract method fails', async () => {
+      await expect(
+        readContracts({
+          allowFailure: false,
+          contracts: [
+            ...contracts,
+            {
+              ...mlootContractConfig,
+              functionName: 'tokenOfOwnerByIndex',
+              args: ['0xA0Cf798816D4b9b9866b5330EEa46a18382f251e', 69420],
+            },
+          ],
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"call revert exception; VM Exception while processing transaction: reverted with reason string \\"ERC721Enumerable: owner index out of bounds\\" [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ] (method=\\"tokenOfOwnerByIndex(address,uint256)\\", data=\\"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002b455243373231456e756d657261626c653a206f776e657220696e646578206f7574206f6620626f756e6473000000000000000000000000000000000000000000\\", errorArgs=[\\"ERC721Enumerable: owner index out of bounds\\"], errorName=\\"Error\\", errorSignature=\\"Error(string)\\", reason=\\"ERC721Enumerable: owner index out of bounds\\", code=CALL_EXCEPTION, version=abi/5.6.1)"`,
+      )
+    })
+
+    it('should not throw if allowFailure=true & a contract has no response', async () => {
+      expect(
+        await readContracts({
+          allowFailure: true,
+          contracts: [
+            ...contracts,
+            {
+              ...wagmigotchiContractConfig,
+              functionName: 'love',
+              // address is not the wagmigotchi contract
+              addressOrName: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              args: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            },
+          ],
+        }),
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "hex": "0x02",
+            "type": "BigNumber",
+          },
+          {
+            "hex": "0x01",
+            "type": "BigNumber",
+          },
+          false,
+          {
+            "hex": "0x05a6db",
+            "type": "BigNumber",
+          },
+          undefined,
+        ]
+      `)
+    })
+
+    it('should throw if allowFailure=false & a contract has no response', async () => {
+      await expect(
+        readContracts({
+          allowFailure: false,
+          contracts: [
+            ...contracts,
+            {
+              ...wagmigotchiContractConfig,
+              functionName: 'love',
+              // address is not the wagmigotchi contract
+              addressOrName: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              args: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            },
+          ],
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`
+              "Function \\"love\\" on contract \\"0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC\\" returned an empty response.
+
+              Are you sure the function \\"love\\" exists on this contract?
+
+              Etherscan: https://etherscan.io/address/0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC#readContract"
+            `)
     })
   })
 })

--- a/packages/core/src/actions/contracts/readContracts.ts
+++ b/packages/core/src/actions/contracts/readContracts.ts
@@ -1,7 +1,10 @@
 import { CallOverrides } from 'ethers/lib/ethers'
 import { Result } from 'ethers/lib/utils'
 
-import { ChainDoesNotSupportMulticallError } from '../../errors'
+import {
+  ChainDoesNotSupportMulticallError,
+  ContractMethodNoDataError,
+} from '../../errors'
 import { getProvider } from '../providers'
 import { multicall } from './multicall'
 import { ReadContractConfig, readContract } from './readContract'
@@ -62,6 +65,8 @@ export async function readContracts<Data extends any[] = Result[]>({
     }
     return (await Promise.all(promises)).flat() as Data
   } catch (err) {
+    if (err instanceof ContractMethodNoDataError) throw err
+
     const promises = contracts.map((contract) =>
       readContract({ ...contract, overrides }),
     )
@@ -70,6 +75,6 @@ export async function readContracts<Data extends any[] = Result[]>({
         result.status === 'fulfilled' ? result.value : null,
       ) as Data
     }
-    return Promise.all(promises) as Promise<Data>
+    return (await Promise.all(promises)) as Data
   }
 }

--- a/packages/core/src/actions/contracts/readContracts.ts
+++ b/packages/core/src/actions/contracts/readContracts.ts
@@ -3,7 +3,7 @@ import { Result } from 'ethers/lib/utils'
 
 import {
   ChainDoesNotSupportMulticallError,
-  ContractMethodNoDataError,
+  ContractMethodNoResultError,
 } from '../../errors'
 import { getProvider } from '../providers'
 import { multicall } from './multicall'
@@ -65,7 +65,7 @@ export async function readContracts<Data extends any[] = Result[]>({
     }
     return (await Promise.all(promises)).flat() as Data
   } catch (err) {
-    if (err instanceof ContractMethodNoDataError) throw err
+    if (err instanceof ContractMethodNoResultError) throw err
 
     const promises = contracts.map((contract) =>
       readContract({ ...contract, overrides }),

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,4 +1,5 @@
 import { Connector } from './connectors'
+import { BlockExplorer } from './constants'
 import { Chain } from './types'
 
 /**
@@ -108,6 +109,34 @@ export class ConnectorAlreadyConnectedError extends Error {
 export class ConnectorNotFoundError extends Error {
   name = 'ConnectorNotFoundError'
   message = 'Connector not found'
+}
+
+export class ContractMethodNoDataError extends Error {
+  name = 'ContractMethodNoDataError'
+
+  constructor({
+    addressOrName,
+    blockExplorer,
+    functionName,
+  }: {
+    addressOrName: string
+    blockExplorer?: BlockExplorer
+    functionName: string
+  }) {
+    super(
+      [
+        `Function "${functionName}" on contract "${addressOrName}" returned an empty response.`,
+        '',
+        `Are you sure the function "${functionName}" exists on this contract?`,
+        ...(blockExplorer
+          ? [
+              '',
+              `${blockExplorer?.name}: ${blockExplorer?.url}/address/${addressOrName}#readContract`,
+            ]
+          : []),
+      ].join('\n'),
+    )
+  }
 }
 
 export class ProviderChainsNotFound extends Error {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -111,8 +111,8 @@ export class ConnectorNotFoundError extends Error {
   message = 'Connector not found'
 }
 
-export class ContractMethodNoDataError extends Error {
-  name = 'ContractMethodNoDataError'
+export class ContractMethodNoResultError extends Error {
+  name = 'ContractMethodNoResultError'
 
   constructor({
     addressOrName,

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -58,6 +58,7 @@ it('should expose correct exports', () => {
       "ChainNotConfiguredError",
       "ConnectorAlreadyConnectedError",
       "ConnectorNotFoundError",
+      "ContractMethodNoResultError",
       "ProviderChainsNotFound",
       "ProviderRpcError",
       "ResourceUnavailableError",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,6 +115,7 @@ export {
   ChainNotConfiguredError,
   ConnectorAlreadyConnectedError,
   ConnectorNotFoundError,
+  ContractMethodNoResultError,
   ProviderChainsNotFound,
   ProviderRpcError,
   ResourceUnavailableError,

--- a/packages/react/src/hooks/contracts/useContractRead.ts
+++ b/packages/react/src/hooks/contracts/useContractRead.ts
@@ -5,7 +5,7 @@ import {
   readContract,
   watchReadContract,
 } from '@wagmi/core'
-import { useQueryClient } from 'react-query'
+import { hashQueryKey, useQueryClient } from 'react-query'
 
 import { QueryConfig, QueryFunctionArgs } from '../../types'
 import { parseContractResult } from '../../utils'
@@ -37,6 +37,12 @@ export const queryKey = ([
       overrides,
     },
   ] as const
+
+const queryKeyHashFn = ([queryKey_]: ReturnType<typeof queryKey>) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { contractInterface, ...rest } = queryKey_
+  return hashQueryKey([rest])
+}
 
 const queryFn = ({
   queryKey: [
@@ -149,6 +155,7 @@ export function useContractRead({
   return useQuery(queryKey_, queryFn, {
     cacheTime,
     enabled,
+    queryKeyHashFn,
     select: (data) => {
       const result = parseContractResult({
         contractInterface,

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -47,6 +47,7 @@ it('should expose correct exports', () => {
       "Connector",
       "ConnectorAlreadyConnectedError",
       "ConnectorNotFoundError",
+      "ContractMethodNoResultError",
       "ProviderChainsNotFound",
       "ProviderRpcError",
       "ResourceUnavailableError",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -51,6 +51,7 @@ export {
   Connector,
   ConnectorAlreadyConnectedError,
   ConnectorNotFoundError,
+  ContractMethodNoResultError,
   ProviderChainsNotFound,
   ProviderRpcError,
   ResourceUnavailableError,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.27.1
       '@typescript-eslint/parser': ^5.27.1
       bundlewatch: ^0.3.3
+      dotenv: ^11.0.0
       eslint: 8.17.0
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-typescript: ^2.7.1
@@ -64,6 +65,7 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.27.1_bnfefdnvqpcyokeggdz5sotnli
       '@typescript-eslint/parser': 5.27.1_pm7osnb22e4oktq33hptgspr5i
       bundlewatch: 0.3.3
+      dotenv: 11.0.0
       eslint: 8.17.0
       eslint-config-prettier: 8.5.0_eslint@8.17.0
       eslint-import-resolver-typescript: 2.7.1_3yxiwxzsqipdmy4jwrlv6vgfmy
@@ -9860,7 +9862,6 @@ packages:
   /dotenv/11.0.0:
     resolution: {integrity: sha512-Fp/b504Y5W+e+FpCxTFMUZ7ZEQkQYF0rx+KZtmwixJxGQbLHrhCwo3FjZgNC8vIfrSi29PABNbMoCGD9YoiXbQ==}
     engines: {node: '>=12'}
-    dev: false
 
   /dotenv/16.0.0:
     resolution: {integrity: sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==}


### PR DESCRIPTION
Fixes #645

## Description

When a contract method returned zero data (`0x`) for any call in a multicall, this would cause the function to throw an error, resulting in the multicall returning nullish data unexpectedly. This PR guards for the case where a call could return zero data, and warns the user that the function does not exist on the targeted contract.