### PR TITLE
docs: missing comma in autoConnect

### DIFF
--- a/docs/pages/docs/client.en-US.mdx
+++ b/docs/pages/docs/client.en-US.mdx
@@ -37,12 +37,10 @@ Enables reconnecting to last used connector on mount. Defaults to `false`.
 import { createClient, configureChains, defaultChains } from 'wagmi'
 import { publicProvider } from 'wagmi/providers/public'
 
-const { provider } = configureChains(defaultChains, [
-  publicProvider(),
-])
+const { provider } = configureChains(defaultChains, [publicProvider()])
 
 const client = createClient({
-  autoConnect: true
+  autoConnect: true,
   provider,
 })
 ```


### PR DESCRIPTION
## Description

Missing comma in autoConnect example

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
