### PR TITLE
fix: broken release

### DIFF
--- a/.changeset/big-candles-kneel.md
+++ b/.changeset/big-candles-kneel.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+Added ethers-compatible `deepEqual` function.

--- a/.changeset/smart-days-reflect.md
+++ b/.changeset/smart-days-reflect.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Fix broken release not containing `deepEqual` from `@wagmi/core`.


### PR DESCRIPTION
## Description

Fix broken release not containing `deepEqual` from `@wagmi/core` (#668 didn't include a release for `@wagmi/core`). Closes #669.

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
