### PR TITLE
Code example needs string parameter

### DIFF
--- a/docs/pages/docs/hooks/useContractWrite.en-US.mdx
+++ b/docs/pages/docs/hooks/useContractWrite.en-US.mdx
@@ -23,7 +23,9 @@ function App() {
     addressOrName: '0xecb504d39723b0be0e3a9aa33d646642d1051ee1',
     contractInterface: wagmigotchiABI,
     functionName: 'feed',
-  })
+  }, 
+  'feed'
+  )
 
   return <button onClick={() => write()}>Feed</button>
 }


### PR DESCRIPTION
The code example given in this useContractWrite documentation file didn't work for me unless I added the function name as a string parameter. I'm not sure why it's not included in the documentation, maybe it's been changed in a recent update or maybe it's assumed the user knows to do this but it was not immediately evident to me.

## Description

_Concise description of proposed changes_

## Additional Information

- [ ] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
