### PR TITLE
fix: update Vite import workaround for Coinbase Wallet SDK

### DIFF
--- a/.changeset/eighty-trains-doubt.md
+++ b/.changeset/eighty-trains-doubt.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/core': patch
+---
+
+Fix import errors with Coinbase Wallet SDK in Vite

--- a/packages/core/src/connectors/coinbaseWallet.ts
+++ b/packages/core/src/connectors/coinbaseWallet.ts
@@ -126,7 +126,11 @@ export class CoinbaseWalletConnector extends Connector<
       let CoinbaseWalletSDK = (await import('@coinbase/wallet-sdk')).default
       // Workaround for Vite dev import errors
       // https://github.com/vitejs/vite/issues/7112
-      if (!CoinbaseWalletSDK.constructor)
+      if (
+        typeof CoinbaseWalletSDK !== 'function' &&
+        // @ts-expect-error This import error is not visible to TypeScript
+        typeof CoinbaseWalletSDK.default === 'function'
+      )
         CoinbaseWalletSDK = (<{ default: typeof CoinbaseWalletSDK }>(
           (<unknown>CoinbaseWalletSDK)
         )).default


### PR DESCRIPTION
## Description

I was having import issues with Coinbase Wallet SDK while trying to use wagmi + RainbowKit in a Vite project. I noticed there's already an attempted workaround for this in wagmi but it didn't seem to work for me.

The original workaround checked whether `CoinbaseWalletSDK` was missing a `constructor` property, but this was evaluating as false because the imported object does have a constructor, i.e. `({}).constructor` exists, evaluating to `Object`.

Instead I'm opting to check whether the `CoinbaseWalletSDK` class is a function, and if it isn't, check whether it has a `default` property that _is_ a function.

By the way, I noticed that the workaround code path isn't used when running the Vite example in the wagmi repo and the regular default import seems to work fine. Were you aware of this? Do you know why this is?

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: markdalgleish.eth
