### PR TITLE
Update useContract.en-US.mdx

### DIFF
--- a/docs/pages/docs/hooks/useContract.en-US.mdx
+++ b/docs/pages/docs/hooks/useContract.en-US.mdx
@@ -77,6 +77,8 @@ function App() {
 
 An ethers [Provider](https://docs.ethers.io/v5/api/providers/provider/#Provider) or [Signer](https://docs.ethers.io/v5/api/signer/#Signer).
 
+If you are using `contract.queryFilter(someFilterHere)` , you need to set a provider.
+
 ```tsx {8}
 import { useContract, useProvider } from 'wagmi'
 


### PR DESCRIPTION
error provider is null when using `contract.queryFilter`

## Description

_Concise description of proposed changes_

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
