### PR TITLE
fix: lock query version

### DIFF
--- a/.changeset/real-insects-hunt.md
+++ b/.changeset/real-insects-hunt.md
@@ -1,0 +1,5 @@
+---
+'wagmi': patch
+---
+
+Lock `react-query` version

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -98,7 +98,7 @@
     "@coinbase/wallet-sdk": "^3.3.0",
     "@wagmi/core": "^0.4.7",
     "@walletconnect/ethereum-provider": "^1.7.8",
-    "react-query": "^4.0.0-beta.23",
+    "react-query": "4.0.0-beta.23",
     "use-sync-external-store": "^1.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,7 +329,7 @@ importers:
       react-17: npm:react@^17.0.2
       react-dom: ^18.1.0
       react-dom-17: npm:react-dom@^17.0.2
-      react-query: ^4.0.0-beta.23
+      react-query: 4.0.0-beta.23
       use-sync-external-store: ^1.1.0
     dependencies:
       '@coinbase/wallet-sdk': 3.3.0


### PR DESCRIPTION
## Description

Lock `react-query` version since it was renamed to `@tanstack/query`

## Additional Information

- [x] I read the [contributing docs](/tmm/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
